### PR TITLE
Fix bug where Sumatra would crash if PDF file was moved/renamed/deleted before printing

### DIFF
--- a/src/Print.cpp
+++ b/src/Print.cpp
@@ -490,6 +490,11 @@ void OnMenuPrint(WindowInfo *win, bool waitForCompletion)
     if (!dm->engine || !dm->engine->AllowsPrinting())
         return;
 
+	if (!file::Exists(dm->engine->FileName())) {
+		MessageBox(win->hwndFrame, _TR("This file has been moved or deleted."), _TR("Printing problem."), MB_ICONEXCLAMATION | MB_OK | (IsUIRightToLeft() ? MB_RTLREADING : 0));
+		return;
+	}
+
     if (win->IsChm()) {
         win->dm->AsChmEngine()->PrintCurrentPage();
         return;


### PR DESCRIPTION
I renamed a file today outside of Sumatra and tried to print it out, but it failed silently on the version that I have installed on my computer. I checked it out from git and tested HEAD, which crashes instead. This patch checks to see if the file still exists and pops up an error dialog if it does not.
