### PR TITLE
Do not display soft hyphens

### DIFF
--- a/src/HtmlFormatter.cpp
+++ b/src/HtmlFormatter.cpp
@@ -741,6 +741,8 @@ void HtmlFormatter::EmitTextRun(const char *s, const char *end)
             currReparseIdx = s - htmlParser->Start();
 
         size_t strLen = str::Utf8ToWcharBuf(s, end - s, buf, dimof(buf));
+        // soft hyphens should not be displayed
+        strLen -= str::RemoveChars(buf, L"\xad");
         textMeasure->SetFont(CurrFont());
         RectF bbox = textMeasure->Measure(buf, strLen);
         EnsureDx(bbox.Width);
@@ -1374,6 +1376,8 @@ void DrawHtmlPage(Graphics *g, mui::ITextRender *textDraw, Vec<DrawInstr> *drawI
         bbox.Y += offY;
         if (InstrString == i.type || InstrRtlString == i.type) {
             size_t strLen = str::Utf8ToWcharBuf(i.str.s, i.str.len, buf, dimof(buf));
+            // soft hyphens should not be displayed
+            strLen -= str::RemoveChars(buf, L"\xad");
             textDraw->Draw(buf, strLen, bbox, InstrRtlString == i.type);
         } else if (InstrSetFont == i.type) {
             textDraw->SetFont(i.font);


### PR DESCRIPTION
Most standards agree soft hyphens should not be displayed when not used
to break words at the end of a line.
Fixes #241