### PR TITLE
Always let user use previous to get back to page 1

### DIFF
--- a/src/EbookController.cpp
+++ b/src/EbookController.cpp
@@ -562,9 +562,9 @@ bool EbookController::GoToPrevPage(bool toBottom)
 {
     UNUSED(toBottom);
     int dist = IsDoublePage() ? 2 : 1;
-    if (currPageNo - dist < 1)
+    if (currPageNo == 1)
         return false;
-    GoToPage(currPageNo - dist, false);
+    GoToPage(currPageNo - dist < 1 ? 1 : currPageNo - dist, false);
     return true;
 }
 


### PR DESCRIPTION
If showing double pages, user could not use previous to get to page 1,
only back to page 2.
Fixes #315 