### PR TITLE
Enable DDE for plugin mode

### DIFF
--- a/src/SumatraPDF.cpp
+++ b/src/SumatraPDF.cpp
@@ -4256,8 +4256,8 @@ InitMouseWheelInfo:
             break;
 
         case WM_DDE_INITIATE:
-            if (gPluginMode)
-                break;
+            //if (gPluginMode)
+            //    break;
             return OnDDEInitiate(hwnd, wParam, lParam);
         case WM_DDE_EXECUTE:
             return OnDDExecute(hwnd, wParam, lParam);


### PR DESCRIPTION
I cannot see why communication over DDE is disabled when SumatraPDF is launched in plugin mode (-plugin command line switch). I tested it, it works flawlessly. Please merge or explain.