### PR TITLE
Resolving issue #727: Keyboard shortcut for Favorites

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -170,7 +170,7 @@ static MenuDef menuDefSettings[] = {
 //[ ACCESSKEY_GROUP Favorites Menu
 // the entire menu is MF_NOT_FOR_EBOOK_UI
 MenuDef menuDefFavorites[] = {
-    { _TRN("Add to favorites"),             IDM_FAV_ADD,                0 },
+    { _TRN("Add to favorites\tCtrl+B"),     IDM_FAV_ADD,                0 },
     { _TRN("Remove from favorites"),        IDM_FAV_DEL,                0 },
     { _TRN("Show Favorites"),               IDM_FAV_TOGGLE,             MF_REQ_DISK_ACCESS },
 };
@@ -312,7 +312,7 @@ static void AppendExternalViewersToMenu(HMENU menuFile, const WCHAR *filePath)
             ParseCmdLine(ev->commandLine, args, 2);
             if (args.Count() == 0)
                 continue;
-            appName.SetCopy(path::GetBaseName(args.At(0)));
+            appName.Set(str::Dup(path::GetBaseName(args.At(0))));
             *(WCHAR *)path::GetExt(appName) = '\0';
         }
 

--- a/src/SumatraPDF.rc
+++ b/src/SumatraPDF.rc
@@ -78,6 +78,7 @@ IDI_PDFDOC              ICON                    "PdfDoc.ico"
 IDC_SUMATRAPDF ACCELERATORS
 BEGIN
     "A",            IDM_SELECT_ALL,         VIRTKEY, CONTROL
+    "B",            IDM_FAV_ADD,            VIRTKEY, CONTROL
     "C",            IDM_COPY_SELECTION,     VIRTKEY, CONTROL
     "D",            IDM_PROPERTIES,         VIRTKEY, CONTROL
     "F",            IDM_FIND_FIRST,         VIRTKEY, CONTROL


### PR DESCRIPTION
Added hotkey Ctrl+B for adding current page to Favorites (with the dialog interactively).
Unfortunately, I don't know how to use scripts\trans_gen,py to update translations. It's neccessary for showing up the hotkey title in main menu -> Favorites -> Add to Favorites