### PR TITLE
Remove highlight by double 'h'

### DIFF
--- a/src/SumatraPDF.cpp
+++ b/src/SumatraPDF.cpp
@@ -3547,7 +3547,15 @@ static void FrameOnChar(WindowInfo& win, WPARAM key, LPARAM info=0)
             if (!win.AsFixed()->userAnnots)
                 win.AsFixed()->userAnnots = new Vec<PageAnnotation>();
             for (SelectionOnPage& sel : *win.currentTab->selectionOnPage) {
-                win.AsFixed()->userAnnots->Append(PageAnnotation(Annot_Highlight, sel.pageNo, sel.rect, PageAnnotation::Color(gGlobalPrefs->annotationDefaults.highlightColor, 0xCC)));
+                auto addedAnnotation = PageAnnotation(Annot_Highlight, sel.pageNo, sel.rect, PageAnnotation::Color(gGlobalPrefs->annotationDefaults.highlightColor, 0xCC));
+                size_t oldLen = win.AsFixed()->userAnnots->Size();
+                for (size_t i = 0; i < oldLen; ++i) {
+                    if (win.AsFixed()->userAnnots->At(i) ==  addedAnnotation)
+                        win.AsFixed()->userAnnots->RemoveAtFast(i);
+                }
+                if (oldLen == win.AsFixed()->userAnnots->Size())
+                    win.AsFixed()->userAnnots->Append(PageAnnotation(Annot_Highlight, sel.pageNo, sel.rect, PageAnnotation::Color(gGlobalPrefs->annotationDefaults.highlightColor, 0xCC)));
+                
                 gRenderCache.Invalidate(win.AsFixed(), sel.pageNo, sel.rect);
             }
             win.AsFixed()->userAnnotsModified = true;


### PR DESCRIPTION
Select the highlighted part, press 'h', the highlight removed.

The logic turns to first check if there is a corresponding highlight, if there is, delete; if not, add.

It is a bit dirty, and only tested with PDF files.