### PR TITLE
Added rotation options to -print-settings command line flag (#1)

### DIFF
--- a/src/ParseCommandLine.cpp
+++ b/src/ParseCommandLine.cpp
@@ -306,7 +306,7 @@ void CommandLineInfo::ParseCommandLine(const WCHAR* cmdLine) {
             printDialog = true;
         } else if (is_arg_with_param(PrintSettings)) {
             // argument is a comma separated list of page ranges and
-            // advanced options [even|odd] and [noscale|shrink|fit]
+            // advanced options [even|odd], [noscale|shrink|fit] and [autorotation|portrait|landscape]
             // e.g. -print-settings "1-3,5,10-8,odd,fit"
             handle_string_param(printSettings);
             str::RemoveChars(printSettings, L" ");

--- a/src/Print.cpp
+++ b/src/Print.cpp
@@ -173,6 +173,12 @@ static bool PrintToDevice(const PrintData& pd, ProgressUpdateUI* progressUI = nu
     bool bPrintPortrait = paperSize.dx < paperSize.dy;
     if (pd.devMode && (pd.devMode.Get()->dmFields & DM_ORIENTATION))
         bPrintPortrait = DMORIENT_PORTRAIT == pd.devMode.Get()->dmOrientation;
+    if (pd.advData.rotation == PrintRotationPortrait) {
+        bPrintPortrait = true;
+    }
+    else if (pd.advData.rotation == PrintRotationLandscape) {
+        bPrintPortrait = false;
+    }
 
     if (pd.sel.Count() > 0) {
         for (int pageNo = 1; pageNo <= engine.PageCount(); pageNo++) {
@@ -747,6 +753,12 @@ static void ApplyPrintSettings(const WCHAR* printerName, const WCHAR* settings, 
             advanced.scale = PrintScaleShrink;
         } else if (str::EqI(rangeList.At(i), L"fit")) {
             advanced.scale = PrintScaleFit;
+        } else if (str::EqI(rangeList.At(i), L"autorotation")) {
+            advanced.rotation = PrintRotationAuto;
+        } else if (str::EqI(rangeList.At(i), L"portrait")) {
+            advanced.rotation = PrintRotationPortrait;
+        } else if (str::EqI(rangeList.At(i), L"landscape")) {
+            advanced.rotation = PrintRotationLandscape;
         } else if (str::Parse(rangeList.At(i), L"%dx%$", &val) && 0 < val && val < 1000) {
             devMode->dmCopies = (short)val;
         } else if (str::EqI(rangeList.At(i), L"simplex")) {

--- a/src/SumatraDialogs.h
+++ b/src/SumatraDialogs.h
@@ -15,14 +15,17 @@ bool      Dialog_AddFavorite(HWND hwnd, const WCHAR *pageNo, AutoFreeW& favName)
 
 enum PrintRangeAdv { PrintRangeAll = 0, PrintRangeEven, PrintRangeOdd };
 enum PrintScaleAdv { PrintScaleNone = 0, PrintScaleShrink, PrintScaleFit };
+enum PrintRotatationAdv { PrintRotationAuto = 0, PrintRotationPortrait, PrintRotationLandscape };
 
 struct Print_Advanced_Data {
     PrintRangeAdv range;
     PrintScaleAdv scale;
+    PrintRotatationAdv rotation;
 
     explicit Print_Advanced_Data(PrintRangeAdv range=PrintRangeAll,
-                        PrintScaleAdv scale=PrintScaleShrink) :
-        range(range), scale(scale) { }
+                        PrintScaleAdv scale=PrintScaleShrink,
+                        PrintRotatationAdv rotation = PrintRotationAuto) :
+        range(range), scale(scale), rotation(rotation) { }
 };
 
 HPROPSHEETPAGE CreatePrintAdvancedPropSheet(Print_Advanced_Data *data, ScopedMem<DLGTEMPLATE>& dlgTemplate);


### PR DESCRIPTION
new -print-settings options are [autorotate|portrait|landscape]
autorotate is the current functionality
portrait forces portait mode (x shorter than y)
landscape forces landscape mode (y shorter than x)

This should be useful with label printers and the like

Hopefully resolves #475