### PR TITLE
Add shortcut to manually add the current page as a navigation point

### DIFF
--- a/src/DisplayModel.h
+++ b/src/DisplayModel.h
@@ -186,6 +186,7 @@ public:
     bool            dontRenderFlag;
 
     bool            GetPresentationMode() const { return presentationMode; }
+    void            AddNavPoint();
 
 protected:
 
@@ -196,7 +197,6 @@ protected:
     PointI          GetContentStart(int pageNo);
     void            RecalcVisibleParts();
     void            RenderVisibleParts();
-    void            AddNavPoint();
     RectD           GetContentBox(int pageNo, RenderTarget target=Target_View);
     void            CalcZoomVirtual(float zoomVirtual);
     void            GoToPage(int pageNo, int scrollY, bool addNavPt=false, int scrollX=-1);

--- a/src/EbookController.h
+++ b/src/EbookController.h
@@ -82,6 +82,7 @@ class EbookController : public Controller {
 
     static void DeleteEbookFormattingData(EbookFormattingData* data);
 
+    void AddNavPoint();
   protected:
     EbookControls* ctrls = nullptr;
 
@@ -125,7 +126,6 @@ class EbookController : public Controller {
     int GetMaxPageCount() const;
     bool IsDoublePage() const;
     void ExtractPageAnchors();
-    void AddNavPoint();
     void OnClickedLink(int pageNo, DrawInstr* link);
 
     // event handlers

--- a/src/SumatraPDF.cpp
+++ b/src/SumatraPDF.cpp
@@ -3437,7 +3437,7 @@ static void FrameOnChar(WindowInfo& win, WPARAM key, LPARAM info=0)
         return;
 
     switch (key) {
-    case VK_SPACE:
+    case VK_SPACE: 
     case VK_RETURN:
         FrameOnKeydown(&win, IsShiftPressed() ? VK_PRIOR : VK_NEXT, 0);
         break;
@@ -3535,6 +3535,16 @@ static void FrameOnChar(WindowInfo& win, WPARAM key, LPARAM info=0)
             if (GetCursorPosInHwnd(win.hwndCanvas, pt)) {
                 UpdateCursorPositionHelper(&win, pt, nullptr);
             }
+        }
+        break;
+    case 'y':
+        // manually add the current page as a naviation point
+        // only DisplayModel and Ebook controllers support this
+        if (win.AsFixed()) {
+            win.AsFixed()->AddNavPoint();
+        }
+        if (win.AsEbook()) {
+            win.AsEbook()->AddNavPoint();
         }
         break;
 #if defined(DEBUG) || defined(SVN_PRE_RELEASE_VER)


### PR DESCRIPTION
Sometimes while reading a document I need to scroll a few pages forward or backward (without clicking on any links or bookmarks) and quickly return to where I was. Now we can do this by pressing the shortcut ('y' as of this commit) before scrolling and then return by hitting backspace.