### PR TITLE
expected is pointer to array. C. f. line 79.

### DIFF
--- a/src/regress/Regress03.cpp
+++ b/src/regress/Regress03.cpp
@@ -96,7 +96,7 @@ void RegressSearch(const WCHAR *filePath, RegressSearchInfo &info)
     const TextSel *expected = BuildTextSelList(info);
     SearchTestWithDir(filePath, searchTerm, FIND_FORWARD, expected, info.count);
     SearchTestWithDir(filePath, searchTerm, FIND_BACKWARD, expected, info.count);
-    delete expected;
+    delete[] expected;
 }
 
 void Regress03()


### PR DESCRIPTION
The function BuildTextSelList() is returning a const pointer pointing to an array. It is something to overlook easily and was found through using [Cppcheck](http://cppcheck.sourceforge.net/). It fixes the only non-deliberate error in #946. I am leaving the issue open to inspire future comitters through the - not resolved - warnings likewise mentioned in the results.xml file. Please edit my comment with respect to grammatical errors too. Many thanks in advance.