### PR TITLE
Solves portability issues (correct casting) from issue #952

### DIFF
--- a/src/utils/SerializeTxt.cpp
+++ b/src/utils/SerializeTxt.cpp
@@ -133,7 +133,7 @@ static void WriteStructWStr(uint8_t* p, WCHAR* s) {
 }
 
 static void WriteStructFloat(uint8_t* p, float f) {
-    float* fp = (float*)p;
+    float* fp = static_cast<float*>(p);
     *fp = f;
 }
 
@@ -173,7 +173,7 @@ static uint64_t ReadStructUInt(const uint8_t* p, Type type) {
 }
 
 static float ReadStructFloat(const uint8_t* p) {
-    float* fp = (float*)p;
+    float* fp = static_cast<float*>(p);
     return *fp;
 }
 

--- a/src/utils/SettingsUtil.cpp
+++ b/src/utils/SettingsUtil.cpp
@@ -193,7 +193,7 @@ static bool SerializeField(str::Str<char>& out, const uint8_t* base, const Field
             out.AppendFmt("%d", *(int*)fieldPtr);
             return true;
         case Type_Float:
-            out.AppendFmt("%g", *(float*)fieldPtr);
+            out.AppendFmt("%g", *static_cast<float*>(fieldPtr));
             return true;
         case Type_Color:
             c = *(COLORREF*)fieldPtr;
@@ -280,7 +280,7 @@ static void DeserializeField(const FieldInfo& field, uint8_t* base, const char* 
             *(int*)fieldPtr = value ? ParseInt(value) : (int)field.value;
             break;
         case Type_Float:
-            str::Parse(value ? value : (const char*)field.value, "%f", (float*)fieldPtr);
+            str::Parse(value ? value : (const char*)field.value, "%f", static_cast<float*>(fieldPtr));
             break;
         case Type_Color:
             if (!value)


### PR DESCRIPTION
A static_cast instead of an old C-style cast allows type model checking at compile time: If an error is made, it is recognized very early.

Signed-off-by: Friedrich Spee von Langenfeld <stehlampen@arcor.de>