### PR TITLE
A6 and A2 support in commandline print

### DIFF
--- a/src/Print.cpp
+++ b/src/Print.cpp
@@ -653,12 +653,16 @@ static short GetPaperSize(BaseEngine* engine) {
     SizeD size = engine->Transform(mediabox, 1, 1.0f / engine->GetFileDPI(), 0).Size();
 
     switch (GetPaperFormat(size)) {
+		case Paper_A2:
+			return DMPAPER_A2;
+		case Paper_A3:
+			return DMPAPER_A3;
         case Paper_A4:
             return DMPAPER_A4;
-        case Paper_A3:
-            return DMPAPER_A3;
         case Paper_A5:
             return DMPAPER_A5;
+		case Paper_A6:
+			return DMPAPER_A6;
         case Paper_Letter:
             return DMPAPER_LETTER;
         case Paper_Legal:
@@ -685,6 +689,9 @@ static short GetPaperByName(const WCHAR* papername) {
     if (str::EqI(papername, L"statement")) {
         return DMPAPER_STATEMENT;
     }
+	if (str::EqI(papername, L"A2")) {
+		return DMPAPER_A2;
+	}
     if (str::EqI(papername, L"A3")) {
         return DMPAPER_A3;
     }
@@ -694,6 +701,9 @@ static short GetPaperByName(const WCHAR* papername) {
     if (str::EqI(papername, L"A5")) {
         return DMPAPER_A5;
     }
+	if (str::EqI(papername, L"A6")) {
+		return DMPAPER_A6;
+	}
     return 0;
 }
 

--- a/src/SumatraProperties.cpp
+++ b/src/SumatraProperties.cpp
@@ -199,12 +199,16 @@ static WCHAR* FormatFileSize(size_t size) {
 PaperFormat GetPaperFormat(SizeD size) {
     SizeD sizeP = size.dx < size.dy ? size : SizeD(size.dy, size.dx);
     // common ISO 216 formats (metric)
-    if (limitValue(sizeP.dx, 8.26, 8.28) == sizeP.dx && limitValue(sizeP.dy, 11.68, 11.70) == sizeP.dy)
-        return Paper_A4;
+    if (limitValue(sizeP.dx, 16.53, 16.55) == sizeP.dx && limitValue(sizeP.dy, 23.38, 23.40) == sizeP.dy)
+        return Paper_A2;
     if (limitValue(sizeP.dx, 11.68, 11.70) == sizeP.dx && limitValue(sizeP.dy, 16.53, 16.55) == sizeP.dy)
         return Paper_A3;
+    if (limitValue(sizeP.dx, 8.26, 8.28) == sizeP.dx && limitValue(sizeP.dy, 11.68, 11.70) == sizeP.dy)
+        return Paper_A4;
     if (limitValue(sizeP.dx, 5.82, 5.85) == sizeP.dx && limitValue(sizeP.dy, 8.26, 8.28) == sizeP.dy)
         return Paper_A5;
+    if (limitValue(sizeP.dx, 4.08, 4.10) == sizeP.dx && limitValue(sizeP.dy, 5.82, 5.85) == sizeP.dy)
+        return Paper_A6;
     // common US/ANSI formats (imperial)
     if (limitValue(sizeP.dx, 8.49, 8.51) == sizeP.dx && limitValue(sizeP.dy, 10.99, 11.01) == sizeP.dy)
         return Paper_Letter;
@@ -225,14 +229,20 @@ static WCHAR* FormatPageSize(BaseEngine* engine, int pageNo, int rotation) {
 
     const WCHAR* formatName = L"";
     switch (GetPaperFormat(size)) {
-        case Paper_A4:
-            formatName = L" (A4)";
+        case Paper_A2:
+            formatName = L" (A2)";
             break;
         case Paper_A3:
             formatName = L" (A3)";
             break;
+        case Paper_A4:
+            formatName = L" (A4)";
+            break;
         case Paper_A5:
             formatName = L" (A5)";
+            break;
+        case Paper_A6:
+            formatName = L" (A6)";
             break;
         case Paper_Letter:
             formatName = L" (Letter)";

--- a/src/SumatraProperties.h
+++ b/src/SumatraProperties.h
@@ -5,9 +5,11 @@
 
 enum PaperFormat {
     Paper_Other,
+    Paper_A2,
+	Paper_A3,
     Paper_A4,
-    Paper_A3,
     Paper_A5,
+    Paper_A6,
     Paper_Letter,
     Paper_Legal,
     Paper_Tabloid,


### PR DESCRIPTION
Hi sumatrapdf :) , 
The purpose of this commit is enabing A6 and A2 paper formats, in command line print. 

I've tested the A6 with three different printers and It works fine. 

About the A2, I don't have access to a printer supporting such format, but It should work since is the exact same logic of the A6. Anyway if you think is not enough to trust it I could remove It.