### PR TITLE
fix CJK line broken problem

### DIFF
--- a/src/HtmlFormatter.cpp
+++ b/src/HtmlFormatter.cpp
@@ -708,10 +708,10 @@ void HtmlFormatter::EmitTextRun(const char* s, const char* end) {
         }
 
         size_t lenThatFits = StringLenForWidth(textMeasure, buf, strLen, pageDx - NewLineX());
-        // try to prevent a break in the middle of a word
+        // try to prevent a break in the middle of a word, CJK support added. 
         if (iswalnum(buf[lenThatFits])) {
             for (size_t len = lenThatFits; len > 0; len--) {
-                if (!iswalnum(buf[len - 1])) {
+                if ((!iswalnum(buf[len - 1])) || (iswalnum(buf[len - 1]) == 256)) {
                     lenThatFits = len;
                     break;
                 }


### PR DESCRIPTION
use iswalnum( ) to identify CJK characters and prevent wrong new-line typesetting(actually, Chinese words break does not affect reading experience )(may have better solution)