### PR TITLE
Don't sort again with inferior sort.

### DIFF
--- a/src/ImagesEngine.cpp
+++ b/src/ImagesEngine.cpp
@@ -872,13 +872,6 @@ bool CbxEngineImpl::LoadFromStream(IStream* stream) {
     return FinishLoading();
 }
 
-static bool cmpArchFileInfoByName(Archive::FileInfo* f1, Archive::FileInfo* f2) {
-    const char* s1 = f1->name.data();
-    const char* s2 = f2->name.data();
-    int res = strcmp(s1, s2);
-    return res < 0;
-}
-
 bool CbxEngineImpl::FinishLoading() {
     CrashIf(!cbxFile);
     if (!cbxFile) {
@@ -914,7 +907,6 @@ bool CbxEngineImpl::FinishLoading() {
         json::Parse(comment.data(), this);
     }
 
-    std::sort(pageFiles.begin(), pageFiles.end(), cmpArchFileInfoByName);
     size_t nFiles = pageFiles.size();
     if (nFiles == 0) {
         return false;


### PR DESCRIPTION
Files were already sorted in ImageDirEngineImpl::LoadImageDir.  Sorting again with strcmp will undo the natural sorting.