### PR TITLE
Fix compilation when using the Windows 10.0.17134.0 (RS4) SDK

### DIFF
--- a/src/utils/WinDynCalls.cpp
+++ b/src/utils/WinDynCalls.cpp
@@ -253,6 +253,8 @@ void NoDllHijacking() {
     }
 }
 
+// As of the Windows 10.0.17134.0 SDK, this struct and ProcessImageLoadPolicy are defined in winnt.h.
+#if !defined(NTDDI_WIN10_RS4)
 #pragma warning(push)
 //  C4201: nonstandard extension used: nameless struct/union
 #pragma warning(disable : 4201)
@@ -272,6 +274,7 @@ typedef struct _PROCESS_MITIGATION_IMAGE_LOAD_POLICY {
 
 // https://msdn.microsoft.com/en-us/library/windows/desktop/hh871470(v=vs.85).aspx
 constexpr int ProcessImageLoadPolicy = 10;
+#endif
 
 // https://github.com/videolan/vlc/blob/8663561d3f71595ebf116f17279a495b67cac713/bin/winvlc.c#L84
 // https://msdn.microsoft.com/en-us/library/windows/desktop/hh769088(v=vs.85).aspx


### PR DESCRIPTION
Hi,

Thanks very much for your work on SumatraPDF!

PR/commit is as per title and should be straightforward. This struct and the value of `ProcessImageLoadPolicy` were moved fom the MSDN documentation to `winnt.h` in the Windows 10 RS4 SDK, which causes a compile time error because these are now redefinitions of existing types.

No functional change intended.