### PR TITLE
fix string_view lifetime bug

### DIFF
--- a/src/wingui/TreeCtrl.cpp
+++ b/src/wingui/TreeCtrl.cpp
@@ -264,13 +264,12 @@ void TreeCtrlVisitNodes(TreeCtrl* w, const TreeItemVisitor& visitor) {
 
 std::wstring_view TreeCtrlGetInfoTip(TreeCtrl* w, HTREEITEM hItem) {
     ZeroArray(w->infotipBuf);
-    WCHAR buf[INFOTIPSIZE + 1] = {0};
     TVITEMW item = {0};
     item.hItem = hItem;
     item.mask = TVIF_TEXT;
-    item.pszText = buf;
+    item.pszText = w->infotipBuf;
     item.cchTextMax = INFOTIPSIZE;
     TreeView_GetItem(w->hwnd, &item);
-    auto res = std::wstring_view(buf);
+    auto res = std::wstring_view(w->infotipBuf);
     return res;
 }


### PR DESCRIPTION
wstring_view is only a non-owning reference. Return a wstring_view from a function local stack variable is wrong because of the lifetime issue. I fix it in this way just because I see the code "ZeroArray(w->infotipBuf)" and I guess it is intent to be the buffer for getting the infotip.

I don't know why this function doesn't simply return a wstring value object, since c++ can do the move semantic right now, it's cheap to do that, maybe it is a better solution?