### PR TITLE
Remove redundant call to CloseFigure. Keep it consistant with define …

### DIFF
--- a/src/Tabs.cpp
+++ b/src/Tabs.cpp
@@ -90,7 +90,6 @@ class TabPainter {
         GraphicsPath shape;
         // define tab's body
         shape.AddRectangle(Rect(0, 0, width, height));
-        shape.CloseFigure();
         shape.SetMarker();
 
         // define "x"'s circle


### PR DESCRIPTION
According to the MSDN, there is no need to call CloseFigure() after the AddRectangle() or AddEllipse() call;
and in the same function, 10 lines below, when the original code use "AddEllipse" to draw the 'x', there is no call to the CloseFigure(). So, for efficiency and consistancy purpose, I removed the redundant CloseFigure() call.