### PR TITLE
Add handle validation check before close

### DIFF
--- a/src/Tabs.cpp
+++ b/src/Tabs.cpp
@@ -90,7 +90,6 @@ class TabPainter {
         GraphicsPath shape;
         // define tab's body
         shape.AddRectangle(Rect(0, 0, width, height));
-        shape.CloseFigure();
         shape.SetMarker();
 
         // define "x"'s circle

--- a/src/utils/ScopedWin.h
+++ b/src/utils/ScopedWin.h
@@ -11,7 +11,10 @@ class ScopedHandle {
 
   public:
     explicit ScopedHandle(HANDLE handle) : handle(handle) {}
-    ~ScopedHandle() { CloseHandle(handle); }
+    ~ScopedHandle() {
+		if (IsValid())
+			CloseHandle(handle); 
+	}
     operator HANDLE() const { return handle; }
     bool IsValid() const { return handle != NULL && handle != INVALID_HANDLE_VALUE; }
 };


### PR DESCRIPTION
According to the MSDN, CloseHandle() "Closes an **open object** handle", and in the remark section it says "If the application is running under a debugger, the function will throw an exception if it receives either a handle value that is not valid or a pseudo-handle value. "，So I add a validation check before close it to make the code more stronger.

Also, when implement the RAII, maybe it's better to implement the "NonCopyable" paradigm for some wrapper, It's zero cost and can make the RAII wrapper much more harder to be misused, It's just a suggestion :). 

