### PR TITLE
Remove BOM character from RTL lists

### DIFF
--- a/mupdf/source/fitz/stext-device.c
+++ b/mupdf/source/fitz/stext-device.c
@@ -884,7 +884,7 @@ ornate_character(fz_text_span *span, int ornate, int character)
 
 /* TODO: Complete these lists... */
 #define ISLEFTTORIGHTCHAR(c) ((0x0041 <= (c) && (c) <= 0x005A) || (0x0061 <= (c) && (c) <= 0x007A) || (0xFB00 <= (c) && (c) <= 0xFB06))
-#define ISRIGHTTOLEFTCHAR(c) ((0x0590 <= (c) && (c) <= 0x05FF) || (0x0600 <= (c) && (c) <= 0x06FF) || (0x0750 <= (c) && (c) <= 0x077F) || (0xFB50 <= (c) && (c) <= 0xFDFF) || (0xFE70 <= (c) && (c) <= 0xFEFF))
+#define ISRIGHTTOLEFTCHAR(c) ((0x0590 <= (c) && (c) <= 0x05FF) || (0x0600 <= (c) && (c) <= 0x06FF) || (0x0750 <= (c) && (c) <= 0x077F) || (0xFB50 <= (c) && (c) <= 0xFDFF) || (0xFE70 <= (c) && (c) <= 0xFEFE))
 
 static void
 fixup_text_span(fz_text_span *span)

--- a/src/TableOfContents.cpp
+++ b/src/TableOfContents.cpp
@@ -392,7 +392,7 @@ void UpdateTocColors(WindowInfo* win) {
     ((0x0041 <= (c) && (c) <= 0x005A) || (0x0061 <= (c) && (c) <= 0x007A) || (0xFB00 <= (c) && (c) <= 0xFB06))
 #define ISRIGHTTOLEFTCHAR(c)                                                                                     \
     ((0x0590 <= (c) && (c) <= 0x05FF) || (0x0600 <= (c) && (c) <= 0x06FF) || (0x0750 <= (c) && (c) <= 0x077F) || \
-     (0xFB50 <= (c) && (c) <= 0xFDFF) || (0xFE70 <= (c) && (c) <= 0xFEFF))
+     (0xFB50 <= (c) && (c) <= 0xFDFF) || (0xFE70 <= (c) && (c) <= 0xFEFE))
 
 static void GetLeftRightCounts(DocTocItem* node, int& l2r, int& r2l) {
     if (!node)


### PR DESCRIPTION
Unicode character 0xFEFF, although often presented along with the
"Arabic Presentation Forms-B" characters, is actually part of the
Specials characters, and represents the Byte Order Marker (BOM),
marking the [big]-endianness (when appearing at the beginning of a
file/stream) or a Zero Width No-Break Space (ZWNBSP) (when appearing
elsewhere).

Accordingly, it's presence in the Right-To-Left list of characters
would make texts seem more Right-to-Left oriented than they really are.

This fixes #1138, where in the table of contents of the submitted PDF
file there was a count of 57 RTL characters, all BOMs, against 4 LTR
characters, setting it's direction as Right-to-Left.