### PR TITLE
Fix bugs and rename func

### DIFF
--- a/src/EngineDump.cpp
+++ b/src/EngineDump.cpp
@@ -425,7 +425,7 @@ int main(int argc, char** argv) {
     UNUSED(argc);
     UNUSED(argv);
     setlocale(LC_ALL, "C");
-    DisableDataExecution();
+    EnableDataExecution();
 
     WStrVec argList;
     ParseCmdLine(GetCommandLine(), argList);

--- a/src/Print.cpp
+++ b/src/Print.cpp
@@ -858,7 +858,7 @@ bool PrintFile(BaseEngine* engine, WCHAR* printerName, bool displayErrors, const
         }
         goto Exit;
     }
-    devMode = AllocStruct<DEVMODE>();
+    devMode = (LPDEVMODE)Allocator::Alloc(nullptr,structSize);
 
     // Get the default DevMode for the printer and modify it for your needs.
     returnCode = DocumentProperties(nullptr, printer, printerName, devMode, /* The address of the buffer to fill. */

--- a/src/SumatraStartup.cpp
+++ b/src/SumatraStartup.cpp
@@ -551,7 +551,7 @@ int APIENTRY WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
     InitDynCalls();
     NoDllHijacking();
 
-    DisableDataExecution();
+    EnableDataExecution();
     // ensure that C functions behave consistently under all OS locales
     // (use Win32 functions where localized input or output is desired)
     setlocale(LC_ALL, "C");

--- a/src/utils/Vec.h
+++ b/src/utils/Vec.h
@@ -362,8 +362,8 @@ class Str : public Vec<T> {
 
     // only available for T = char
     OwnedData StealAsOwnedData() {
-        char* s = this->StealData();
         size_t size = this->size();
+        char* s = this->StealData();
         return OwnedData(s, size);
     }
 };

--- a/src/utils/WinUtil.cpp
+++ b/src/utils/WinUtil.cpp
@@ -283,7 +283,7 @@ WCHAR* GetSpecialFolder(int csidl, bool createIfMissing) {
     return str::Dup(path);
 }
 
-void DisableDataExecution() {
+void EnableDataExecution() {
     // first try the documented SetProcessDEPPolicy
     if (DynSetProcessDEPPolicy) {
         DynSetProcessDEPPolicy(PROCESS_DEP_ENABLE);

--- a/src/utils/WinUtil.h
+++ b/src/utils/WinUtil.h
@@ -53,7 +53,7 @@ bool CreateRegKey(HKEY keySub, const WCHAR* keyName);
 bool DeleteRegKey(HKEY keySub, const WCHAR* keyName, bool resetACLFirst = false);
 WCHAR* GetSpecialFolder(int csidl, bool createIfMissing = false);
 
-void DisableDataExecution();
+void EnableDataExecution();
 void RedirectIOToConsole();
 WCHAR* GetExePath();
 WCHAR* GetExeDir();


### PR DESCRIPTION
The old DisableDataExecution() intends to "EnableDataExecution). It desires a change.

(Print.cpp)I have tested the code near devMode. I find that there is an exception in the program when executing the second DocumentProperties(). As I observe, the reason is the buffer is not enough.  I find that the structSize returned by DocumentProperties() is above 4000(driver-specific). However, sizeof(DEVMODE) is below 100. This leads to an overflow. 

(Vec.h) StealData() will set the size to zero, which leads to that this->size() always return 0. That is excatly what we want.