### PR TITLE
Change default color value of MainWindowBackground

### DIFF
--- a/scripts/gen_settingsstructs.py
+++ b/scripts/gen_settingsstructs.py
@@ -367,7 +367,7 @@ GlobalPrefs = [
 	Comment("For documentation, see https://www.sumatrapdfreader.org/settings%s.html" % util.get_sumatrapdf_version()),
 	EmptyLine(),
 
-	Field("MainWindowBackground", Color, RGB(0xFF, 0xF2, 0x00, a=0x80),
+	Field("MainWindowBackground", Color, RGB(0xFF, 0xF2, 0x00),
 		"background color of the non-document windows, traditionally yellow",
 		expert=True),
 


### PR DESCRIPTION
If you open portable sumatrapdf in a new folder, the default value in MainWindowBackground is:
MainWindowBackground = #80fff200
And the the color will be setted with last six char fff200 and ignore 80.

Anyway #80fff200 is not match in settings3.2.html

Last line change is due to file not end with /n