### PR TITLE
add option to exit when double cliking on the menu button

### DIFF
--- a/src/Caption.cpp
+++ b/src/Caption.cpp
@@ -16,6 +16,7 @@
 #include "Translations.h"
 #include "resource.h"
 #include "Menu.h"
+#include "GlobalPrefs.h"
 
 using namespace Gdiplus;
 
@@ -166,6 +167,12 @@ static LRESULT CALLBACK WndProcCaption(HWND hwnd, UINT message, WPARAM wParam, L
                         SetTimer(hwnd, DO_NOT_REOPEN_MENU_TIMER_ID, DO_NOT_REOPEN_MENU_DELAY_IN_MS, nullptr);
                     }
                     SetFocus(win->hwndFrame);
+                }
+            } else if (win && BN_DBLCLK == HIWORD(wParam) && gGlobalPrefs->menuButtonDblClickExit) {
+                WORD button = LOWORD(wParam) - BTN_ID_FIRST;
+                if (button == CB_MENU) {
+                    // Menu button double clicked, exit now
+                    SendMessage(win->hwndFrame, WM_CLOSE, 0, 0);
                 }
             }
             break;

--- a/src/SettingsStructs.h
+++ b/src/SettingsStructs.h
@@ -372,6 +372,9 @@ struct GlobalPrefs {
     bool showStartPage;
     // if true, documents are opened in tabs instead of new windows
     bool useTabs;
+    // if true and useTabs is enabled, double clicking on the menu button will exit
+    // (to match windows behavior when double clicking on system icon on the left of the titlebar).
+    bool menuButtonDblClickExit;
     // information about opened files (in most recently used order)
     Vec<FileState*>* fileStates;
     // state of the last session, usage depends on RestoreSession
@@ -635,6 +638,7 @@ static const FieldInfo gGlobalPrefsFields[] = {
     {offsetof(GlobalPrefs, tocDy), Type_Int, 0},
     {offsetof(GlobalPrefs, showStartPage), Type_Bool, true},
     {offsetof(GlobalPrefs, useTabs), Type_Bool, true},
+    {offsetof(GlobalPrefs, menuButtonDblClickExit), Type_Bool, false},
     {(size_t)-1, Type_Comment, 0},
     {offsetof(GlobalPrefs, fileStates), Type_Array, (intptr_t)&gFileStateInfo},
     {offsetof(GlobalPrefs, sessionData), Type_Array, (intptr_t)&gSessionDataInfo},
@@ -651,7 +655,7 @@ static const StructInfo gGlobalPrefsInfo = {
     "ement\0\0PrinterDefaults\0ForwardSearch\0AnnotationDefaults\0DefaultPasswords\0CustomScreenDPI\0\0RememberStatePer"
     "Document\0UiLanguage\0ShowToolbar\0ShowFavorites\0AssociatedExtensions\0AssociateSilently\0CheckForUpdates\0Versio"
     "nToSkip\0RememberOpenedFiles\0InverseSearchCmdLine\0EnableTeXEnhancements\0DefaultDisplayMode\0DefaultZoom\0Window"
-    "State\0WindowPos\0ShowToc\0SidebarDx\0TocDy\0ShowStartPage\0UseTabs\0\0FileStates\0SessionData\0ReopenOnce\0TimeOf"
-    "LastUpdateCheck\0OpenCountWeek\0\0"};
+    "State\0WindowPos\0ShowToc\0SidebarDx\0TocDy\0ShowStartPage\0UseTabs\0MenuButtonDblClickExit\0\0FileStates\0Session"
+    "Data\0ReopenOnce\0TimeOfLastUpdateCheck\0OpenCountWeek\0\0"};
 
 #endif

--- a/src/SumatraDialogs.cpp
+++ b/src/SumatraDialogs.cpp
@@ -685,6 +685,8 @@ static INT_PTR CALLBACK Dialog_Settings_Proc(HWND hDlg, UINT msg, WPARAM wParam,
                            prefs->rememberStatePerDocument ? BST_CHECKED : BST_UNCHECKED);
             EnableWindow(GetDlgItem(hDlg, IDC_REMEMBER_STATE_PER_DOCUMENT), prefs->rememberOpenedFiles);
             CheckDlgButton(hDlg, IDC_USE_TABS, prefs->useTabs ? BST_CHECKED : BST_UNCHECKED);
+            CheckDlgButton(hDlg, IDC_MENU_BUTTON_DBL_CLICK_EXIT,
+                           prefs->menuButtonDblClickExit ? BST_CHECKED : BST_UNCHECKED);
             CheckDlgButton(hDlg, IDC_CHECK_FOR_UPDATES, prefs->checkForUpdates ? BST_CHECKED : BST_UNCHECKED);
             EnableWindow(GetDlgItem(hDlg, IDC_CHECK_FOR_UPDATES), HasPermission(Perm_InternetAccess));
             CheckDlgButton(hDlg, IDC_REMEMBER_OPENED_FILES, prefs->rememberOpenedFiles ? BST_CHECKED : BST_UNCHECKED);
@@ -708,6 +710,7 @@ static INT_PTR CALLBACK Dialog_Settings_Proc(HWND hDlg, UINT msg, WPARAM wParam,
             SetDlgItemText(hDlg, IDC_REMEMBER_STATE_PER_DOCUMENT, _TR("&Remember these settings for each document"));
             SetDlgItemText(hDlg, IDC_SECTION_ADVANCED, _TR("Advanced"));
             SetDlgItemText(hDlg, IDC_USE_TABS, _TR("Use &tabs"));
+            SetDlgItemText(hDlg, IDC_MENU_BUTTON_DBL_CLICK_EXIT, _TR("Exit when double-clicking on &menu button"));
             SetDlgItemText(hDlg, IDC_CHECK_FOR_UPDATES, _TR("Automatically check for &updates"));
             SetDlgItemText(hDlg, IDC_REMEMBER_OPENED_FILES, _TR("Remember &opened files"));
             SetDlgItemText(hDlg, IDC_SECTION_INVERSESEARCH, _TR("Set inverse search command-line"));
@@ -761,6 +764,7 @@ static INT_PTR CALLBACK Dialog_Settings_Proc(HWND hDlg, UINT msg, WPARAM wParam,
                     prefs->rememberStatePerDocument =
                         (BST_CHECKED == IsDlgButtonChecked(hDlg, IDC_REMEMBER_STATE_PER_DOCUMENT));
                     prefs->useTabs = (BST_CHECKED == IsDlgButtonChecked(hDlg, IDC_USE_TABS));
+                    prefs->menuButtonDblClickExit = (BST_CHECKED == IsDlgButtonChecked(hDlg, IDC_MENU_BUTTON_DBL_CLICK_EXIT));
                     prefs->checkForUpdates = (BST_CHECKED == IsDlgButtonChecked(hDlg, IDC_CHECK_FOR_UPDATES));
                     prefs->rememberOpenedFiles = (BST_CHECKED == IsDlgButtonChecked(hDlg, IDC_REMEMBER_OPENED_FILES));
                     if (prefs->enableTeXEnhancements && HasPermission(Perm_DiskAccess)) {

--- a/src/SumatraPDF.rc
+++ b/src/SumatraPDF.rc
@@ -218,7 +218,7 @@ BEGIN
     PUSHBUTTON      "&No, thanks",IDCANCEL,184,49,70,14
 END
 
-IDD_DIALOG_SETTINGS DIALOGEX 0, 0, 240, 241
+IDD_DIALOG_SETTINGS DIALOGEX 0, 0, 240, 254
 STYLE DS_SETFONT | DS_MODALFRAME | DS_SETFOREGROUND | DS_FIXEDSYS | DS_CENTER | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Settings"
 FONT 8, "MS Shell Dlg", 400, 0, 0x1
@@ -232,18 +232,20 @@ BEGIN
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,12,53,216,9
     CONTROL         "&Remember these settings for each document",IDC_REMEMBER_STATE_PER_DOCUMENT,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,12,66,216,9
-    GROUPBOX        "Advanced",IDC_SECTION_ADVANCED,6,87,228,70
+    GROUPBOX        "Advanced",IDC_SECTION_ADVANCED,6,87,228,83
     CONTROL         "Use &tabs",IDC_USE_TABS,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,12,97,216,9
-    CONTROL         "Automatically check for &updates",IDC_CHECK_FOR_UPDATES,
+    CONTROL         "Exit when double-clicking on &menu button",IDC_MENU_BUTTON_DBL_CLICK_EXIT,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,12,110,216,9
-    CONTROL         "Remember &opened files",IDC_REMEMBER_OPENED_FILES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,12,123,216,9
-    PUSHBUTTON      "Make SumatraPDF a default PDF reader",IDC_SET_DEFAULT_READER,12,137,216,14
-    GROUPBOX        "Set inverse search command-line",IDC_SECTION_INVERSESEARCH,6,163,228,52
-    LTEXT           "Enter the command-line to invoke when you double-click on the PDF document:",IDC_CMDLINE_LABEL,12,175,216,18
-    COMBOBOX        IDC_CMDLINE,12,195,216,13,CBS_DROPDOWN | CBS_AUTOHSCROLL | CBS_HASSTRINGS | CBS_DISABLENOSCROLL | WS_TABSTOP
-    DEFPUSHBUTTON   "OK",IDOK,128,221,50,14
-    PUSHBUTTON      "Cancel",IDCANCEL,184,221,50,14
+    CONTROL         "Automatically check for &updates",IDC_CHECK_FOR_UPDATES,
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,12,123,216,9
+    CONTROL         "Remember &opened files",IDC_REMEMBER_OPENED_FILES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,12,136,216,9
+    PUSHBUTTON      "Make SumatraPDF a default PDF reader",IDC_SET_DEFAULT_READER,12,150,216,14
+    GROUPBOX        "Set inverse search command-line",IDC_SECTION_INVERSESEARCH,6,176,228,52
+    LTEXT           "Enter the command-line to invoke when you double-click on the PDF document:",IDC_CMDLINE_LABEL,12,188,216,18
+    COMBOBOX        IDC_CMDLINE,12,208,216,13,CBS_DROPDOWN | CBS_AUTOHSCROLL | CBS_HASSTRINGS | CBS_DISABLENOSCROLL | WS_TABSTOP
+    DEFPUSHBUTTON   "OK",IDOK,128,234,50,14
+    PUSHBUTTON      "Cancel",IDCANCEL,184,234,50,14
 END
 
 IDD_DIALOG_CUSTOM_ZOOM DIALOGEX 0, 0, 116, 60

--- a/src/SumatraStartup.cpp
+++ b/src/SumatraStartup.cpp
@@ -344,6 +344,8 @@ static bool SetupPluginMode(CommandLineInfo& i) {
     gGlobalPrefs->reuseInstance = false;
     // don't allow tabbed navigation
     gGlobalPrefs->useTabs = false;
+    // don't exit on double click on menu button
+    gGlobalPrefs->menuButtonDblClickExit = false;
     // always display the toolbar when embedded (as there's no menubar in that case)
     gGlobalPrefs->showToolbar = true;
     // never allow esc as a shortcut to quit

--- a/src/resource.h
+++ b/src/resource.h
@@ -156,6 +156,7 @@
 #define IDC_CMDLINE_LABEL               1041
 #define IDC_CMDLINE                     1042
 #define IDC_USE_TABS                    1045
+#define IDC_MENU_BUTTON_DBL_CLICK_EXIT  1046
 #define IDC_SECTION_PRINT_RANGE         1050
 #define IDC_PRINT_RANGE_ALL             1051
 #define IDC_PRINT_RANGE_EVEN            1052


### PR DESCRIPTION
This commit add a boolean option MenuButtonDblClickExit.
When true, a double click on the menu button will cause SumatraPDF to
exit (the menu button is only shown when UseTabs is true).

This allows to close SumatraPDF like other Windows application using a
double click on left top icon of the title bar.
The double click duration is the one configured in Windows' settings.

Issue: #162