### PR TITLE
caption: add system icon to exit when double cliking and move window on drag

### DIFF
--- a/src/Caption.h
+++ b/src/Caption.h
@@ -17,6 +17,7 @@ enum CaptionButtons {
     CB_RESTORE,
     CB_CLOSE,
     CB_MENU,
+    CB_SYSTEM_MENU,
     CB_BTN_COUNT
 };
 


### PR DESCRIPTION
This commit add a new button in the caption bar as the system icon.
This allow to close the application on double click and to move the window
when dragging the button (useful when the titlebar is otherwise full of
tabs).

That new icon use the main window icon as would do Windows.

Issues: #162, #1053, #423
Related: #1372