### PR TITLE
EnginePdf: fix memory leak when rendering is aborted

### DIFF
--- a/src/EngineDjVu.cpp
+++ b/src/EngineDjVu.cpp
@@ -160,7 +160,6 @@ struct DjVuContext {
         }
         LeaveCriticalSection(&lock);
         DeleteCriticalSection(&lock);
-        minilisp_finish();
     }
 
     void SpinMessageLoop(bool wait = true) {
@@ -222,12 +221,12 @@ static void ReleaseDjVuContext() {
 }
 
 void CleanupDjVuEngine() {
-    if (!gDjVuContext) {
-        return;
+    if (gDjVuContext) {
+        CrashIf(gDjVuContext->refCount != 0);
+        delete gDjVuContext;
+        gDjVuContext = nullptr;
     }
-    CrashIf(gDjVuContext->refCount != 0);
-    delete gDjVuContext;
-    gDjVuContext = nullptr;
+    minilisp_finish();
 }
 
 class EngineDjVu : public EngineBase {

--- a/src/EnginePdf.cpp
+++ b/src/EnginePdf.cpp
@@ -1173,10 +1173,10 @@ RenderedBitmap* EnginePdf::RenderPage(RenderPageArgs& args) {
         fz_run_page_transparency(ctx, pageAnnots, dev, cliprect, true, transparency);
         fz_run_user_page_annots(ctx, pageAnnots, dev, ctm, cliprect, fzcookie);
         bitmap = new_rendered_fz_pixmap(ctx, pix);
+        fz_close_device(ctx, dev);
     }
     fz_always(ctx) {
         if (dev) {
-            fz_close_device(ctx, dev);
             fz_drop_device(ctx, dev);
         }
         fz_drop_pixmap(ctx, pix);


### PR DESCRIPTION
When the rendering (here in `fz_run_display_list`) is aborted, a memory
leak can occur as `fz_close_device` can throw in case of "items left on
stack in draw device".
This happens when zooming out and in.

When `fz_close_device` throws, `fz_drop_device` and `fz_drop_pixmap`
are not executed and so a memory leak occurs.

With this commit, if the rendering is aborted in a way that causes
`fz_close_device` to throw, `EnginePdf::RenderPage` function will
just return a null pointer as it would with any errors, without memory
leak.

Issue: #1393