### PR TITLE
Fix config file permissions in build.go

### DIFF
--- a/do/build.go
+++ b/do/build.go
@@ -195,7 +195,7 @@ func setBuildConfigDaily() {
 	panicIf(preRelVer == "")
 	s += fmt.Sprintf("#define PRE_RELEASE_VER %s\n", preRelVer)
 	s += "#define IS_DAILY_BUILD 1\n"
-	err := ioutil.WriteFile(buildConfigPath(), []byte(s), 644)
+	err := ioutil.WriteFile(buildConfigPath(), []byte(s), 0644)
 	panicIfErr(err)
 }
 
@@ -203,14 +203,14 @@ func setBuildConfigPreRelease() {
 	s := getBuildConfigCommon()
 	preRelVer := getPreReleaseVer()
 	s += fmt.Sprintf("#define PRE_RELEASE_VER %s\n", preRelVer)
-	err := ioutil.WriteFile(buildConfigPath(), []byte(s), 644)
+	err := ioutil.WriteFile(buildConfigPath(), []byte(s), 0644)
 	panicIfErr(err)
 }
 
 func setBuildConfigRelease() {
 	s := getBuildConfigCommon()
 	s += "#define SUMATRA_UPDATE_INFO_URL L\"https://www.sumatrapdfreader.org/update-check-rel.txt\"\n"
-	err := ioutil.WriteFile(buildConfigPath(), []byte(s), 644)
+	err := ioutil.WriteFile(buildConfigPath(), []byte(s), 0644)
 	panicIfErr(err)
 }
 


### PR DESCRIPTION
Changed created file permissions from 644 (`-w----r--`) to 0644 (`rw-r--r--`) when calling `WriteFile(...)`.

PoC:
```
dc@jhtc:~/gogo$ cat main.go
package main

import "io/ioutil"

func main() {
    ioutil.WriteFile("644", []byte("content"), 644)
    ioutil.WriteFile("0644", []byte("content"), 0644)
}
dc@jhtc:~/gogo$ go run main.go
dc@jhtc:~/gogo$ ls -la
total 28
drwxrwxr-x   2 dc dc  4096 Jun  9 16:42 .
drwxr-xr-x 124 dc dc 12288 Jun  9 16:42 ..
-rw-r--r--   1 dc dc     7 Jun  9 16:42 0644
--w----r--   1 dc dc     7 Jun  9 16:42 644
-rw-rw-r--   1 dc dc   156 Jun  9 16:42 main.go
```