### PR TITLE
Show information icon instead of exclamation warning, if no updates available

### DIFF
--- a/src/SumatraPDF.cpp
+++ b/src/SumatraPDF.cpp
@@ -2053,7 +2053,7 @@ static DWORD ShowAutoUpdateDialog(HWND hParent, HttpRsp* rsp, bool silent) {
     if (!hasUpdate) {
         /* if automated => don't notify that there is no new version */
         if (!silent) {
-            MessageBoxWarning(hParent, _TR("You have the latest version."), _TR("SumatraPDF Update"));
+            MessageBoxA(hParent, _TR("You have the latest version."), _TR("SumatraPDF Update"), MB_ICONINFORMATION | MB_OK | MB_SETFOREGROUND | MB_TOPMOST);
         }
         return 0;
     }


### PR DESCRIPTION
When checking for updates, the warning icon is shown in the message box if there are none.

A calmer information icon should be shown if the user already has the latest version.