### PR TITLE
Add option to hide scrollbars for PDFs

### DIFF
--- a/do/gen_settings_structs.go
+++ b/do/gen_settings_structs.go
@@ -357,6 +357,8 @@ var (
 				"suggested values: #2828aa #28aa28 #aa2828"),
 		mkField("InvertColors", Bool, false,
 			"if true, TextColor and BackgroundColor will be temporarily swapped").setInternal(),
+		mkField("HideScrollbars", Bool, false,
+			"if true, hides the scrollbars but retain ability to scroll").setInternal(),
 	}
 
 	ebookUI = []*Field{

--- a/src/AppPrefs.cpp
+++ b/src/AppPrefs.cpp
@@ -239,6 +239,7 @@ bool Reload() {
     }
 
     UpdateDocumentColors();
+    UpdateFixedPageScrollbarsVisibility();
     return true;
 }
 

--- a/src/Canvas.cpp
+++ b/src/Canvas.cpp
@@ -1182,6 +1182,12 @@ static LRESULT WndProcCanvasFixedPageUI(WindowInfo* win, HWND hwnd, UINT msg, WP
         case WM_GESTURE:
             return OnGesture(win, msg, wp, lp);
 
+        case WM_NCPAINT:
+            if (gGlobalPrefs->hideScrollbars) {
+                ShowScrollBar(win->hwndCanvas, SB_BOTH, FALSE);
+            }
+            return TRUE;
+
         default:
             return DefWindowProc(hwnd, msg, wp, lp);
     }

--- a/src/Canvas.cpp
+++ b/src/Canvas.cpp
@@ -1330,7 +1330,7 @@ static void OnTimer(WindowInfo* win, HWND hwnd, WPARAM timerId) {
         case REPAINT_TIMER_ID:
             win->delayedRepaintTimer = 0;
             KillTimer(hwnd, REPAINT_TIMER_ID);
-            win->RedrawAllIncludingNonClient(TRUE);
+            win->RedrawAllIncludingNonClient(true);
             break;
 
         case SMOOTHSCROLL_TIMER_ID:

--- a/src/Commands.h
+++ b/src/Commands.h
@@ -26,6 +26,7 @@
     V(ViewFullScreen, "View: FullScreen")                             \
     V(ViewPresentationMode, "View: Presentation Mode")                \
     V(ViewShowHideToolbar, "View: Toogle Toolbar")                    \
+    V(ViewShowHideScrollbars, "View: Toogle Scrollbars")              \
     V(ViewShowHideMenuBar, "View: Toggle Menu Bar")                   \
     V(CopySelection, "Copy Selection")                                \
     V(SelectAll, "Select All")                                        \

--- a/src/DisplayModel.cpp
+++ b/src/DisplayModel.cpp
@@ -185,11 +185,11 @@ Rect DisplayModel::GetViewPort() const {
 }
 
 bool DisplayModel::NeedHScroll() const {
-    return viewPort.dy < totalViewPortSize.dy;
+    return viewPort.dx < canvasSize.dx;
 }
 
 bool DisplayModel::NeedVScroll() const {
-    return viewPort.dx < totalViewPortSize.dx;
+    return viewPort.dy < canvasSize.dy;
 }
 
 Size DisplayModel::GetCanvasSize() const {
@@ -696,8 +696,11 @@ RestartLayout:
         }
         pos.y = currPosY;
 
-        // restart the layout if we detect we need to show scrollbars
-        if (!needVScroll && viewPort.dy < currPosY + rowMaxPageDy) {
+        // restart the layout if we detect we need to show scrollbars, skip if
+        //   scrollbars are being hidden or if `needVScroll` has already been
+        //   set to true (i.e., the block has been processed)
+        if ((!gGlobalPrefs->hideScrollbars) && (!needVScroll)
+                && viewPort.dy < currPosY + rowMaxPageDy) {
             needVScroll = true;
             viewPort.dx -= GetSystemMetrics(SM_CXVSCROLL);
             goto RestartLayout;
@@ -711,9 +714,13 @@ RestartLayout:
             columnMaxWidth[pageInARow] = pos.dx;
         }
 
-        if (!needHScroll && viewPort.dx < windowMargin.left + columnMaxWidth[0] +
-                                              (columns == 2 ? pageSpacing.dx + columnMaxWidth[1] : 0) +
-                                              windowMargin.right) {
+        // restart the layout if we detect we need to show scrollbars, skip if
+        //   scrollbars are being hidden or if `needHScroll` has already been
+        //   set to true (i.e., the block has been processed)
+        if ((!gGlobalPrefs->hideScrollbars) && (!needHScroll)
+                && viewPort.dx < windowMargin.left + columnMaxWidth[0]
+                + (columns == 2 ? pageSpacing.dx + columnMaxWidth[1] : 0)
+                + windowMargin.right) {
             needHScroll = true;
             viewPort.dy -= GetSystemMetrics(SM_CYHSCROLL);
             goto RestartLayout;
@@ -738,7 +745,8 @@ RestartLayout:
     // restart the layout if we detect we need to show scrollbars
     // (there are some edge cases we can't catch in the above loop)
     const int canvasDy = currPosY + windowMargin.bottom - pageSpacing.dy;
-    if (!needVScroll && canvasDy > viewPort.dy) {
+    if ((!gGlobalPrefs->hideScrollbars) && (!needVScroll)
+            && canvasDy > viewPort.dy) {
         needVScroll = true;
         viewPort.dx -= GetSystemMetrics(SM_CXVSCROLL);
         goto RestartLayout;
@@ -757,7 +765,8 @@ RestartLayout:
     // (there are some edge cases we can't catch in the above loop)
     int canvasDx = windowMargin.left + columnMaxWidth[0] + (columns == 2 ? pageSpacing.dx + columnMaxWidth[1] : 0) +
                    windowMargin.right;
-    if (!needHScroll && canvasDx > viewPort.dx) {
+    if ((!gGlobalPrefs->hideScrollbars) && (!needHScroll)
+            && canvasDx > viewPort.dx) {
         needHScroll = true;
         viewPort.dy -= GetSystemMetrics(SM_CYHSCROLL);
         goto RestartLayout;

--- a/src/DisplayModel.cpp
+++ b/src/DisplayModel.cpp
@@ -184,6 +184,14 @@ Rect DisplayModel::GetViewPort() const {
     return viewPort;
 }
 
+bool DisplayModel::hScrollbarShown() const {
+    return viewPort.dx < totalViewPortSize.dx;
+}
+
+bool DisplayModel::vScrollbarShown() const {
+    return viewPort.dy < totalViewPortSize.dy;
+}
+
 bool DisplayModel::NeedHScroll() const {
     return viewPort.dx < canvasSize.dx;
 }
@@ -699,7 +707,7 @@ RestartLayout:
         // restart the layout if we detect we need to show scrollbars, skip if
         //   scrollbars are being hidden or if `needVScroll` has already been
         //   set to true (i.e., the block has been processed)
-        if ((!gGlobalPrefs->hideScrollbars) && (!needVScroll)
+        if ((!gGlobalPrefs->fixedPageUI.hideScrollbars) && (!needVScroll)
                 && viewPort.dy < currPosY + rowMaxPageDy) {
             needVScroll = true;
             viewPort.dx -= GetSystemMetrics(SM_CXVSCROLL);
@@ -717,7 +725,7 @@ RestartLayout:
         // restart the layout if we detect we need to show scrollbars, skip if
         //   scrollbars are being hidden or if `needHScroll` has already been
         //   set to true (i.e., the block has been processed)
-        if ((!gGlobalPrefs->hideScrollbars) && (!needHScroll)
+        if ((!gGlobalPrefs->fixedPageUI.hideScrollbars) && (!needHScroll)
                 && viewPort.dx < windowMargin.left + columnMaxWidth[0]
                 + (columns == 2 ? pageSpacing.dx + columnMaxWidth[1] : 0)
                 + windowMargin.right) {
@@ -745,7 +753,7 @@ RestartLayout:
     // restart the layout if we detect we need to show scrollbars
     // (there are some edge cases we can't catch in the above loop)
     const int canvasDy = currPosY + windowMargin.bottom - pageSpacing.dy;
-    if ((!gGlobalPrefs->hideScrollbars) && (!needVScroll)
+    if ((!gGlobalPrefs->fixedPageUI.hideScrollbars) && (!needVScroll)
             && canvasDy > viewPort.dy) {
         needVScroll = true;
         viewPort.dx -= GetSystemMetrics(SM_CXVSCROLL);
@@ -765,7 +773,7 @@ RestartLayout:
     // (there are some edge cases we can't catch in the above loop)
     int canvasDx = windowMargin.left + columnMaxWidth[0] + (columns == 2 ? pageSpacing.dx + columnMaxWidth[1] : 0) +
                    windowMargin.right;
-    if ((!gGlobalPrefs->hideScrollbars) && (!needHScroll)
+    if ((!gGlobalPrefs->fixedPageUI.hideScrollbars) && (!needHScroll)
             && canvasDx > viewPort.dx) {
         needHScroll = true;
         viewPort.dy -= GetSystemMetrics(SM_CYHSCROLL);

--- a/src/DisplayModel.cpp
+++ b/src/DisplayModel.cpp
@@ -184,11 +184,11 @@ Rect DisplayModel::GetViewPort() const {
     return viewPort;
 }
 
-bool DisplayModel::hScrollbarShown() const {
+bool DisplayModel::IsHScrollbarVisible() const {
     return viewPort.dx < totalViewPortSize.dx;
 }
 
-bool DisplayModel::vScrollbarShown() const {
+bool DisplayModel::IsVScrollbarVisible() const {
     return viewPort.dy < totalViewPortSize.dy;
 }
 

--- a/src/DisplayModel.h
+++ b/src/DisplayModel.h
@@ -135,8 +135,8 @@ struct DisplayModel : public Controller {
     void Relayout(float zoomVirtual, int rotation);
 
     Rect GetViewPort() const;
-    bool hScrollbarShown() const;
-    bool vScrollbarShown() const;
+    bool IsHScrollbarVisible() const;
+    bool IsVScrollbarVisible() const;
     bool NeedHScroll() const;
     bool NeedVScroll() const;
     Size GetCanvasSize() const;

--- a/src/DisplayModel.h
+++ b/src/DisplayModel.h
@@ -135,6 +135,8 @@ struct DisplayModel : public Controller {
     void Relayout(float zoomVirtual, int rotation);
 
     Rect GetViewPort() const;
+    bool hScrollbarShown() const;
+    bool vScrollbarShown() const;
     bool NeedHScroll() const;
     bool NeedVScroll() const;
     Size GetCanvasSize() const;

--- a/src/EditAnnotations.cpp
+++ b/src/EditAnnotations.cpp
@@ -113,7 +113,7 @@ AnnotationType gAnnotsWithColor[] = {
 // clang-format on
 
 // in SumatraPDF.cpp
-extern void WindowInfoRerender(WindowInfo*);
+extern void WindowInfoRerender(WindowInfo*, bool = FALSE);
 
 const char* GetKnownColorName(COLORREF c) {
     if (c == ColorUnset) {

--- a/src/EditAnnotations.cpp
+++ b/src/EditAnnotations.cpp
@@ -113,7 +113,7 @@ AnnotationType gAnnotsWithColor[] = {
 // clang-format on
 
 // in SumatraPDF.cpp
-extern void WindowInfoRerender(WindowInfo*, bool = FALSE);
+extern void WindowInfoRerender(WindowInfo*, bool includeNonClientArea = false);
 
 const char* GetKnownColorName(COLORREF c) {
     if (c == ColorUnset) {

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -696,7 +696,7 @@ static bool ShouldShowCreateAnnotationMenu(TabInfo* tab, int x, int y) {
 }
 
 // in SumatraPDF.cpp
-extern void WindowInfoRerender(WindowInfo*);
+extern void WindowInfoRerender(WindowInfo*, bool = FALSE);
 
 void OnWindowContextMenu(WindowInfo* win, int x, int y) {
     DisplayModel* dm = win->AsFixed();

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -140,6 +140,7 @@ static MenuDef menuDefView[] = {
     { SEP_ITEM,                             0,                        MF_REQ_FULLSCREEN },
     { _TRN("Show Book&marks\tF12"),         CmdViewBookmarks,         0 },
     { _TRN("Show &Toolbar\tF8"),            CmdViewShowHideToolbar,   MF_NOT_FOR_EBOOK_UI },
+    { _TRN("Show Scr&ollbars"),             CmdViewShowHideScrollbars,MF_NOT_FOR_CHM | MF_NOT_FOR_EBOOK_UI },
     { SEP_ITEM,                             0,                        MF_REQ_ALLOW_COPY | MF_NOT_FOR_EBOOK_UI },
     { _TRN("Select &All\tCtrl+A"),          CmdSelectAll,             MF_REQ_ALLOW_COPY | MF_NOT_FOR_EBOOK_UI },
     { _TRN("&Copy Selection\tCtrl+C"),      CmdCopySelection,         MF_REQ_ALLOW_COPY | MF_NOT_FOR_EBOOK_UI },
@@ -252,6 +253,7 @@ static MenuDef menuDefContext[] = {
     { _TRN("Show &Favorites"),              CmdFavoriteToggle,        0                 },
     { _TRN("Show &Bookmarks\tF12"),         CmdViewBookmarks,         0                 },
     { _TRN("Show &Toolbar\tF8"),            CmdViewShowHideToolbar,   MF_NOT_FOR_EBOOK_UI },
+    { _TRN("Show &Scrollbars"),             CmdViewShowHideScrollbars,MF_NOT_FOR_CHM | MF_NOT_FOR_EBOOK_UI },
     { _TRN("Save Annotations"),             CmdSaveAnnotationsSmx,    MF_REQ_DISK_ACCESS },
     {"New Bookmarks",                       CmdNewBookmarks,          MF_NO_TRANSLATE },
     { _TR_TODON("Edit Annotations"),        CmdEditAnnotations,       MF_REQ_DISK_ACCESS },
@@ -579,6 +581,7 @@ static void MenuUpdateStateForWindow(WindowInfo* win) {
 
     win::menu::SetChecked(win->menu, CmdFavoriteToggle, gGlobalPrefs->showFavorites);
     win::menu::SetChecked(win->menu, CmdViewShowHideToolbar, gGlobalPrefs->showToolbar);
+    win::menu::SetChecked(win->menu, CmdViewShowHideScrollbars, !gGlobalPrefs->fixedPageUI.hideScrollbars);
     MenuUpdateDisplayMode(win);
     MenuUpdateZoom(win);
 
@@ -767,6 +770,8 @@ void OnWindowContextMenu(WindowInfo* win, int x, int y) {
     win::menu::SetEnabled(popup, CmdViewBookmarks, win->ctrl->HacToc());
     win::menu::SetChecked(popup, CmdViewBookmarks, win->tocVisible);
 
+    win::menu::SetChecked(popup, CmdViewShowHideScrollbars, !gGlobalPrefs->fixedPageUI.hideScrollbars);
+
     win::menu::SetEnabled(popup, CmdFavoriteToggle, HasFavorites());
     win::menu::SetChecked(popup, CmdFavoriteToggle, gGlobalPrefs->showFavorites);
 
@@ -841,6 +846,7 @@ void OnWindowContextMenu(WindowInfo* win, int x, int y) {
         case CmdFavoriteToggle:
         case CmdProperties:
         case CmdViewShowHideToolbar:
+        case CmdViewShowHideScrollbars:
         case CmdSaveAnnotationsSmx:
         case CmdNewBookmarks:
             HwndSendCommand(win->hwndFrame, cmd);

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -696,7 +696,7 @@ static bool ShouldShowCreateAnnotationMenu(TabInfo* tab, int x, int y) {
 }
 
 // in SumatraPDF.cpp
-extern void WindowInfoRerender(WindowInfo*, bool = FALSE);
+extern void WindowInfoRerender(WindowInfo*, bool includeNonClientArea = false);
 
 void OnWindowContextMenu(WindowInfo* win, int x, int y) {
     DisplayModel* dm = win->AsFixed();

--- a/src/SettingsStructs.h
+++ b/src/SettingsStructs.h
@@ -362,6 +362,7 @@ struct GlobalPrefs {
     bool showStartPage;
     // if true, documents are opened in tabs instead of new windows
     bool useTabs;
+    bool hideScrollbars;
     // information about opened files (in most recently used order)
     Vec<FileState*>* fileStates;
     // state of the last session, usage depends on RestoreSession
@@ -627,6 +628,7 @@ static const FieldInfo gGlobalPrefsFields[] = {
     {offsetof(GlobalPrefs, treeFontSize), Type_Int, 0},
     {offsetof(GlobalPrefs, showStartPage), Type_Bool, true},
     {offsetof(GlobalPrefs, useTabs), Type_Bool, true},
+    {offsetof(GlobalPrefs, hideScrollbars), Type_Bool, true},
     {(size_t)-1, Type_Comment, 0},
     {offsetof(GlobalPrefs, fileStates), Type_Array, (intptr_t)&gFileStateInfo},
     {offsetof(GlobalPrefs, sessionData), Type_Array, (intptr_t)&gSessionDataInfo},
@@ -637,14 +639,14 @@ static const FieldInfo gGlobalPrefsFields[] = {
     {(size_t)-1, Type_Comment, (intptr_t) "Settings after this line have not been recognized by the current version"},
 };
 static const StructInfo gGlobalPrefsInfo = {
-    sizeof(GlobalPrefs), 55, gGlobalPrefsFields,
+    sizeof(GlobalPrefs), 56, gGlobalPrefsFields,
     "\0\0MainWindowBackground\0EscToExit\0ReuseInstance\0UseSysColors\0RestoreSession\0TabWidth\0\0FixedPageUI\0EbookUI"
     "\0ComicBookUI\0ChmUI\0ExternalViewers\0ShowMenubar\0ReloadModifiedDocuments\0FullPathInTitle\0ZoomLevels\0ZoomIncr"
     "ement\0\0PrinterDefaults\0ForwardSearch\0AnnotationDefaults\0DefaultPasswords\0CustomScreenDPI\0\0RememberStatePer"
     "Document\0UiLanguage\0ShowToolbar\0ShowFavorites\0AssociatedExtensions\0AssociateSilently\0CheckForUpdates\0Versio"
     "nToSkip\0RememberOpenedFiles\0InverseSearchCmdLine\0EnableTeXEnhancements\0DefaultDisplayMode\0DefaultZoom\0Window"
-    "State\0WindowPos\0ShowToc\0SidebarDx\0TocDy\0TreeFontSize\0ShowStartPage\0UseTabs\0\0FileStates\0SessionData\0Reop"
-    "enOnce\0TimeOfLastUpdateCheck\0OpenCountWeek\0\0"};
+    "State\0WindowPos\0ShowToc\0SidebarDx\0TocDy\0TreeFontSize\0ShowStartPage\0UseTabs\0HideScrollbars\0\0FileStates\0S"
+    "essionData\0ReopenOnce\0TimeOfLastUpdateCheck\0OpenCountWeek\0\0"};
 
 #endif
 

--- a/src/SettingsStructs.h
+++ b/src/SettingsStructs.h
@@ -408,11 +408,10 @@ static const FieldInfo gFixedPageUIFields[] = {
     {offsetof(FixedPageUI, windowMargin), Type_Compact, (intptr_t)&gWindowMarginInfo},
     {offsetof(FixedPageUI, pageSpacing), Type_Compact, (intptr_t)&gSizeInfo},
     {offsetof(FixedPageUI, gradientColors), Type_ColorArray, 0},
-    {offsetof(FixedPageUI, hideScrollbars), Type_Bool, false},
 };
 static const StructInfo gFixedPageUIInfo = {
-    sizeof(FixedPageUI), 7, gFixedPageUIFields,
-    "TextColor\0BackgroundColor\0SelectionColor\0WindowMargin\0PageSpacing\0GradientColors\0HideScrollbars"};
+    sizeof(FixedPageUI), 6, gFixedPageUIFields,
+    "TextColor\0BackgroundColor\0SelectionColor\0WindowMargin\0PageSpacing\0GradientColors"};
 
 static const FieldInfo gEbookUIFields[] = {
     {offsetof(EbookUI, fontName), Type_String, (intptr_t)L"Georgia"},

--- a/src/SettingsStructs.h
+++ b/src/SettingsStructs.h
@@ -44,6 +44,8 @@ struct FixedPageUI {
     Vec<COLORREF>* gradientColors;
     // if true, TextColor and BackgroundColor will be temporarily swapped
     bool invertColors;
+    // if true, hides the scrollbars but retain ability to scroll
+    bool hideScrollbars;
 };
 
 // customization options for eBooks (EPUB, Mobi, FictionBook) UI. If
@@ -362,7 +364,6 @@ struct GlobalPrefs {
     bool showStartPage;
     // if true, documents are opened in tabs instead of new windows
     bool useTabs;
-    bool hideScrollbars;
     // information about opened files (in most recently used order)
     Vec<FileState*>* fileStates;
     // state of the last session, usage depends on RestoreSession
@@ -407,10 +408,11 @@ static const FieldInfo gFixedPageUIFields[] = {
     {offsetof(FixedPageUI, windowMargin), Type_Compact, (intptr_t)&gWindowMarginInfo},
     {offsetof(FixedPageUI, pageSpacing), Type_Compact, (intptr_t)&gSizeInfo},
     {offsetof(FixedPageUI, gradientColors), Type_ColorArray, 0},
+    {offsetof(FixedPageUI, hideScrollbars), Type_Bool, false},
 };
 static const StructInfo gFixedPageUIInfo = {
-    sizeof(FixedPageUI), 6, gFixedPageUIFields,
-    "TextColor\0BackgroundColor\0SelectionColor\0WindowMargin\0PageSpacing\0GradientColors"};
+    sizeof(FixedPageUI), 7, gFixedPageUIFields,
+    "TextColor\0BackgroundColor\0SelectionColor\0WindowMargin\0PageSpacing\0GradientColors\0HideScrollbars"};
 
 static const FieldInfo gEbookUIFields[] = {
     {offsetof(EbookUI, fontName), Type_String, (intptr_t)L"Georgia"},
@@ -628,7 +630,6 @@ static const FieldInfo gGlobalPrefsFields[] = {
     {offsetof(GlobalPrefs, treeFontSize), Type_Int, 0},
     {offsetof(GlobalPrefs, showStartPage), Type_Bool, true},
     {offsetof(GlobalPrefs, useTabs), Type_Bool, true},
-    {offsetof(GlobalPrefs, hideScrollbars), Type_Bool, true},
     {(size_t)-1, Type_Comment, 0},
     {offsetof(GlobalPrefs, fileStates), Type_Array, (intptr_t)&gFileStateInfo},
     {offsetof(GlobalPrefs, sessionData), Type_Array, (intptr_t)&gSessionDataInfo},
@@ -639,14 +640,14 @@ static const FieldInfo gGlobalPrefsFields[] = {
     {(size_t)-1, Type_Comment, (intptr_t) "Settings after this line have not been recognized by the current version"},
 };
 static const StructInfo gGlobalPrefsInfo = {
-    sizeof(GlobalPrefs), 56, gGlobalPrefsFields,
+    sizeof(GlobalPrefs), 55, gGlobalPrefsFields,
     "\0\0MainWindowBackground\0EscToExit\0ReuseInstance\0UseSysColors\0RestoreSession\0TabWidth\0\0FixedPageUI\0EbookUI"
     "\0ComicBookUI\0ChmUI\0ExternalViewers\0ShowMenubar\0ReloadModifiedDocuments\0FullPathInTitle\0ZoomLevels\0ZoomIncr"
     "ement\0\0PrinterDefaults\0ForwardSearch\0AnnotationDefaults\0DefaultPasswords\0CustomScreenDPI\0\0RememberStatePer"
     "Document\0UiLanguage\0ShowToolbar\0ShowFavorites\0AssociatedExtensions\0AssociateSilently\0CheckForUpdates\0Versio"
     "nToSkip\0RememberOpenedFiles\0InverseSearchCmdLine\0EnableTeXEnhancements\0DefaultDisplayMode\0DefaultZoom\0Window"
-    "State\0WindowPos\0ShowToc\0SidebarDx\0TocDy\0TreeFontSize\0ShowStartPage\0UseTabs\0HideScrollbars\0\0FileStates\0S"
-    "essionData\0ReopenOnce\0TimeOfLastUpdateCheck\0OpenCountWeek\0\0"};
+    "State\0WindowPos\0ShowToc\0SidebarDx\0TocDy\0TreeFontSize\0ShowStartPage\0UseTabs\0\0FileStates\0SessionData\0Reop"
+    "enOnce\0TimeOfLastUpdateCheck\0OpenCountWeek\0\0"};
 
 #endif
 

--- a/src/SumatraPDF.cpp
+++ b/src/SumatraPDF.cpp
@@ -3336,6 +3336,11 @@ static void OnMenuViewShowHideToolbar() {
     }
 }
 
+static void OnMenuViewShowHideScrollbars() {
+    gGlobalPrefs->fixedPageUI.hideScrollbars = !gGlobalPrefs->fixedPageUI.hideScrollbars;
+    UpdateFixedPageScrollbarsVisibility();
+}
+
 static void OnMenuAdvancedOptions() {
     if (!HasPermission(Perm_DiskAccess) || !HasPermission(Perm_SavePreferences)) {
         return;
@@ -4472,6 +4477,10 @@ static LRESULT FrameOnCommand(WindowInfo* win, HWND hwnd, UINT msg, WPARAM wp, L
 
         case CmdViewShowHideToolbar:
             OnMenuViewShowHideToolbar();
+            break;
+
+        case CmdViewShowHideScrollbars:
+            OnMenuViewShowHideScrollbars();
             break;
 
         case CmdSaveAnnotationsSmx:

--- a/src/SumatraPDF.cpp
+++ b/src/SumatraPDF.cpp
@@ -2168,7 +2168,7 @@ void UpdateCheckAsync(WindowInfo* win, bool autoCheck) {
 }
 
 // re-render the document currently displayed in this window
-void WindowInfoRerender(WindowInfo* win, bool includeNonClientArea = FALSE) {
+void WindowInfoRerender(WindowInfo* win, bool includeNonClientArea = false) {
     if (!win->AsFixed()) {
         return;
     }
@@ -2191,7 +2191,7 @@ static void RerenderEverything() {
 static void RerenderFixedPage() {
     for (auto* win : gWindows) {
         if (win->AsFixed()) {
-            WindowInfoRerender(win, TRUE);
+            WindowInfoRerender(win, true);
         }
     }
 }
@@ -2219,12 +2219,12 @@ void UpdateDocumentColors() {
 
 void UpdateFixedPageScrollbarsVisibility() {
     bool hideScrollbars = gGlobalPrefs->fixedPageUI.hideScrollbars;
-    bool scrollbarsVisible = FALSE; // assume no scrollbars by default
+    bool scrollbarsVisible = false; // assume no scrollbars by default
 
     // iterate through each fixed page window to check whether scrollbars are shown
     for (auto* win : gWindows) {
         if (auto* pdfWin = win->AsFixed()) {
-            scrollbarsVisible = pdfWin->vScrollbarShown() || pdfWin->hScrollbarShown();
+            scrollbarsVisible = pdfWin->IsVScrollbarVisible() || pdfWin->IsHScrollbarVisible();
             if (scrollbarsVisible) {
                 break;
             }

--- a/src/SumatraPDF.h
+++ b/src/SumatraPDF.h
@@ -119,6 +119,7 @@ void AdvanceFocus(WindowInfo* win);
 bool WindowInfoStillValid(WindowInfo* win);
 void SetCurrentLanguageAndRefreshUI(const char* langCode);
 void UpdateDocumentColors();
+void UpdateFixedPageScrollbarsVisibility();
 void UpdateTabFileDisplayStateForTab(TabInfo* tab);
 bool FrameOnKeydown(WindowInfo* win, WPARAM key, LPARAM lp, bool inTextfield = false);
 void ReloadDocument(WindowInfo* win, bool autoRefresh);

--- a/src/WindowInfo.cpp
+++ b/src/WindowInfo.cpp
@@ -172,6 +172,16 @@ void WindowInfo::RedrawAll(bool update) {
     }
 }
 
+void WindowInfo::RedrawAllIncludingNonClient(bool update) {
+    InvalidateRect(this->hwndCanvas, nullptr, false);
+    if (this->AsEbook()) {
+        this->AsEbook()->RequestRepaint();
+    }
+    if (update) {
+        RedrawWindow(this->hwndCanvas, NULL, NULL, RDW_FRAME | RDW_INVALIDATE);
+    }
+}
+
 void WindowInfo::ChangePresentationMode(PresentationMode mode) {
     presentation = mode;
     if (PM_BLACK_SCREEN == mode || PM_WHITE_SCREEN == mode) {

--- a/src/WindowInfo.h
+++ b/src/WindowInfo.h
@@ -224,6 +224,7 @@ struct WindowInfo {
     void UpdateCanvasSize();
     Size GetViewPortSize();
     void RedrawAll(bool update = false);
+    void RedrawAllIncludingNonClient(bool update = false);
 
     void ChangePresentationMode(PresentationMode mode);
 


### PR DESCRIPTION
I added an option to hide/show scrollbars for my own use, and thought I'll share it upstream. If this feature is useful, do let me know how the code could be tidied up before merging in.

### Details:
 - Added `HideScrollbars` to the settings, under `FixedPageUI`
 - Scrollbars will be hidden / shown for PDFs based on the option
 - Works for fullscreen single page continuous mode, also tested on the modes that are accessible via shortcut keys Ctrl+1 / 2 / 3 / 5 / 6 / 7 / 8 / 0

### Demonstration:
![toggling-scrollbars-visibility](https://user-images.githubusercontent.com/14101781/85971972-3d09af80-ba01-11ea-8952-5c66063fd3cd.gif)

and with overlap showing key-presses:
![toggling-scrollbars-visibility-with-keys-overlay](https://user-images.githubusercontent.com/14101781/85972701-498f0780-ba03-11ea-8e1f-24519a30ba86.gif)


### Previous discussions:
 - #1307
 - #1211 
 - https://forum.sumatrapdfreader.org/t/add-option-to-hide-scrollbar/705/5?u=sumatrapeter

