### PR TITLE
#1280 add translation and searching of selected text

### DIFF
--- a/do/gen_settings_structs.go
+++ b/do/gen_settings_structs.go
@@ -389,7 +389,7 @@ var (
 	externalViewer = []*Field{
 		mkField("CommandLine", String, nil,
 			"command line with which to call the external viewer, may contain "+
-				"%p for page number and \"%1\" for the file name (add quotation "+
+				"%p for page number, %s for active selection and \"%1\" for the file name (add quotation "+
 				"marks around paths containing spaces)"),
 		mkField("Name", String, nil,
 			"name of the external viewer to be shown in the menu (implied by CommandLine if missing)"),

--- a/src/ExternalViewers.cpp
+++ b/src/ExternalViewers.cpp
@@ -356,7 +356,7 @@ bool ViewWithExternalViewer(TabInfo* tab, size_t idx) {
 
     // if the command line contains %p, it's replaced with the current page number
     // if it contains %1, it's replaced with the file path
-    // else if it contains %$ it's replaced with active selection
+    // else if it contains %s it's replaced with active selection
     // else file path is appended
 
     const WCHAR* cmdLine = args.size() > 1 ? args.at(1) : L"\"%1\"";

--- a/src/ExternalViewers.cpp
+++ b/src/ExternalViewers.cpp
@@ -353,7 +353,10 @@ bool ViewWithExternalViewer(TabInfo* tab, size_t idx) {
     }
 
     // if the command line contains %p, it's replaced with the current page number
-    // if it contains %1, it's replaced with the file path (else the file path is appended)
+    // if it contains %1, it's replaced with the file path
+    // else if it contains %$ it's replaced with active selection
+    // else file path is appended
+
     const WCHAR* cmdLine = args.size() > 1 ? args.at(1) : L"\"%1\"";
     AutoFreeWstr params;
     if (str::Find(cmdLine, L"%p")) {
@@ -363,6 +366,12 @@ bool ViewWithExternalViewer(TabInfo* tab, size_t idx) {
     }
     if (str::Find(cmdLine, L"%1")) {
         params.Set(str::Replace(cmdLine, L"%1", tab->filePath));
+    } else if (str::Find(cmdLine, L"%$")) {
+        bool isTextOnlySelection;
+        WCHAR* selection = GetSelectedText(tab->win, L", ", isTextOnlySelection);
+        if (isTextOnlySelection) {
+            params.Set(str::Replace(cmdLine, L"%$", selection));
+        }
     } else {
         params.Set(str::Format(L"%s \"%s\"", cmdLine, tab->filePath.Get()));
     }

--- a/src/ExternalViewers.cpp
+++ b/src/ExternalViewers.cpp
@@ -372,7 +372,7 @@ bool ViewWithExternalViewer(TabInfo* tab, size_t idx) {
         if (str::Find(cmdLine, L"%2")) {
             bool isTextOnlySelection;
             WCHAR* selection = GetSelectedText(tab->win, L", ", isTextOnlySelection);
-            params.Set(str::Replace(cmdLine, L"%2", selection));
+            params.Set(str::Replace(cmdLine, L"%2", selection ? selection : L""));
         } else {
             params.Set(str::Format(L"%s \"%s\"", cmdLine, tab->filePath.Get()));
         }

--- a/src/ExternalViewers.cpp
+++ b/src/ExternalViewers.cpp
@@ -12,6 +12,7 @@
 #include "Annotation.h"
 #include "EngineBase.h"
 #include "EngineCreate.h"
+#include "TextSelection.h"
 
 #include "DisplayMode.h"
 #include "SettingsStructs.h"
@@ -20,6 +21,7 @@
 
 #include "SumatraPDF.h"
 #include "TabInfo.h"
+#include "Selection.h"
 #include "ExternalViewers.h"
 
 static WCHAR* GetAcrobatPath() {
@@ -366,14 +368,14 @@ bool ViewWithExternalViewer(TabInfo* tab, size_t idx) {
     }
     if (str::Find(cmdLine, L"%1")) {
         params.Set(str::Replace(cmdLine, L"%1", tab->filePath));
-    } else if (str::Find(cmdLine, L"%$")) {
-        bool isTextOnlySelection;
-        WCHAR* selection = GetSelectedText(tab->win, L", ", isTextOnlySelection);
-        if (isTextOnlySelection) {
-            params.Set(str::Replace(cmdLine, L"%$", selection));
-        }
     } else {
-        params.Set(str::Format(L"%s \"%s\"", cmdLine, tab->filePath.Get()));
+        if (str::Find(cmdLine, L"%2")) {
+            bool isTextOnlySelection;
+            WCHAR* selection = GetSelectedText(tab->win, L", ", isTextOnlySelection);
+            params.Set(str::Replace(cmdLine, L"%2", selection));
+        } else {
+            params.Set(str::Format(L"%s \"%s\"", cmdLine, tab->filePath.Get()));
+        }
     }
     return LaunchFile(args.at(0), params);
 }

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -372,8 +372,7 @@ static void AddFileMenuItem(HMENU menuFile, const WCHAR* filePath, int index) {
     AutoFreeWstr menuString;
     menuString.SetCopy(path::GetBaseNameNoFree(filePath));
     auto fileName = win::menu::ToSafeString(menuString);
-    int menuIdx = (int)((index + 1) % 10);
-    menuString.Set(str::Format(L"&%d) %s", menuIdx, fileName));
+    menuString.Set(str::Format(L"%s", fileName));
     uint menuId = CmdFileHistoryFirst + index;
     uint flags = MF_BYCOMMAND | MF_ENABLED | MF_STRING;
     InsertMenuW(menuFile, CmdExit, flags, menuId, menuString);
@@ -429,7 +428,7 @@ static void AppendExternalViewersToMenu(HMENU menuFile, const WCHAR* filePath) {
             *(WCHAR*)path::GetExtNoFree(appName) = '\0';
         }
 
-        AutoFreeWstr menuString(str::Format(_TR("Open in %s"), appName ? appName.Get() : name));
+        AutoFreeWstr menuString(str::Format(_TR("&%u. %s"), i + 1, appName ? appName.Get() : name));
         uint menuId = CmdOpenWithExternalFirst + count;
         InsertMenuW(menuFile, CmdSendByEmail, MF_BYCOMMAND | MF_ENABLED | MF_STRING, menuId, menuString);
         if (!filePath) {

--- a/src/SettingsStructs.h
+++ b/src/SettingsStructs.h
@@ -87,7 +87,7 @@ struct ChmUI {
 // multiple entries for the same format)
 struct ExternalViewer {
     // command line with which to call the external viewer, may contain %p
-    // for page number and "%1" for the file name (add quotation marks
+    // for page number, %s for active selection, and "%1" for the file name (add quotation marks
     // around paths containing spaces)
     WCHAR* commandLine;
     // name of the external viewer to be shown in the menu (implied by


### PR DESCRIPTION
# Introduction
As discussed on #1280, adding a feature to send selected text to external viewers with `%2`.

# Changes
1. Changed `ExternalViewers#ViewWithExternalViewer` to replace %2 with selected text
2. Changed `Menu#AppendExternalViewersToMenu` to add the index and shortcut to menu under `File` submenu
3. Changed `Menu#AddFileMenuItem` to remove the index of recent files

# ToDo
1. Update docs -> Mention the use of %2 and add some examples.
2. For multi-word selections, the url string must be enclosed in double quotes OR we need to implement URL safe encoding and first encode the selection before querying.