### PR TITLE
Make number of most recently used files configurable

### DIFF
--- a/do/gen_settings_structs.go
+++ b/do/gen_settings_structs.go
@@ -626,6 +626,10 @@ var (
 			"if true, we show a list of frequently read documents when no document is loaded"),
 		mkField("UseTabs", Bool, true,
 			"if true, documents are opened in tabs instead of new windows").setVersion("3.0"),
+		mkField("FileHistoryMaxRecent", Int, 10,
+			"number of most recently used files that will be shown in the menu "+
+			"(and remembered in the preferences file, if just filenames are "+
+			"to be remembered and not individual view settings per document)").setExpert().setVersion("3.3"),
 		mkEmptyLine(),
 
 		// file history and favorites

--- a/docs/releasenotes.txt
+++ b/docs/releasenotes.txt
@@ -2,6 +2,7 @@
 the release notes, as we make them, to make the release process easier.
 
 Next version:
+* made number of most recently used files configurable in expert mode
 
 3.2 (2020-03-15)
 * upgraded core PDF parsing rendering to latest version of mupdf. Faster, less bugs.

--- a/src/FileHistory.cpp
+++ b/src/FileHistory.cpp
@@ -137,7 +137,7 @@ bool FileHistory::MarkFileInexistent(const WCHAR* filePath, bool hide) {
     // so that the user could still try opening it again
     // and so that we don't completely forget the settings,
     // should the file reappear later on
-    int newIdx = hide ? INT_MAX : FILE_HISTORY_MAX_RECENT - 1;
+    int newIdx = hide ? INT_MAX : gGlobalPrefs->fileHistoryMaxRecent - 1;
     int idx = states->Find(state);
     if (idx < newIdx && state != states->Last()) {
         states->Remove(state);
@@ -182,7 +182,7 @@ void FileHistory::Purge(bool alwaysUseDefaultState) {
     if (alwaysUseDefaultState) {
         Vec<DisplayState*> frequencyList;
         GetFrequencyOrder(frequencyList);
-        if (frequencyList.size() > FILE_HISTORY_MAX_RECENT) {
+        if (gGlobalPrefs->fileHistoryMaxRecent < 0 || frequencyList.size() > static_cast<size_t>(gGlobalPrefs->fileHistoryMaxRecent)) {
             minOpenCount = frequencyList.at(FILE_HISTORY_MAX_FREQUENT)->openCount / 2;
         }
     }
@@ -200,7 +200,9 @@ void FileHistory::Purge(bool alwaysUseDefaultState) {
         } else if (j > FILE_HISTORY_MAX_FILES) {
             // forget about files last opened longer ago than the last FILE_HISTORY_MAX_FILES ones
             states->RemoveAt(j - 1);
-        } else if (alwaysUseDefaultState && state->openCount < minOpenCount && j > FILE_HISTORY_MAX_RECENT) {
+        } else if (alwaysUseDefaultState && state->openCount < minOpenCount &&
+                   (gGlobalPrefs->fileHistoryMaxRecent < 0 ||
+                    j > static_cast<size_t>(gGlobalPrefs->fileHistoryMaxRecent))) {
             // forget about files that were hardly used (and without valuable state)
             states->RemoveAt(j - 1);
         } else {

--- a/src/FileHistory.h
+++ b/src/FileHistory.h
@@ -1,11 +1,6 @@
 /* Copyright 2020 the SumatraPDF project authors (see AUTHORS file).
    License: GPLv3 */
 
-// number of most recently used files that will be shown in the menu
-// (and remembered in the preferences file, if just filenames are
-//  to be remembered and not individual view settings per document)
-#define FILE_HISTORY_MAX_RECENT 10
-
 // maximum number of most frequently used files that will be shown on the
 // Frequent Read list (space permitting)
 #define FILE_HISTORY_MAX_FREQUENT 10

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -372,7 +372,7 @@ static void AddFileMenuItem(HMENU menuFile, const WCHAR* filePath, int index) {
     AutoFreeWstr menuString;
     menuString.SetCopy(path::GetBaseNameNoFree(filePath));
     auto fileName = win::menu::ToSafeString(menuString);
-    int menuIdx = (int)((index + 1) % 10);
+    int menuIdx = (int)((index + 1));
     menuString.Set(str::Format(L"&%d) %s", menuIdx, fileName));
     uint menuId = CmdFileHistoryFirst + index;
     uint flags = MF_BYCOMMAND | MF_ENABLED | MF_STRING;
@@ -385,7 +385,7 @@ static void AppendRecentFilesToMenu(HMENU m) {
     }
 
     int i;
-    for (i = 0; i < FILE_HISTORY_MAX_RECENT; i++) {
+    for (i = 0; i < gGlobalPrefs->fileHistoryMaxRecent; i++) {
         DisplayState* state = gFileHistory.Get(i);
         if (!state || state->isMissing) {
             break;

--- a/src/SettingsStructs.h
+++ b/src/SettingsStructs.h
@@ -359,6 +359,10 @@ struct GlobalPrefs {
     bool showStartPage;
     // if true, documents are opened in tabs instead of new windows
     bool useTabs;
+    // number of most recently used files that will be shown in the menu
+    // (and remembered in the preferences file, if just filenames are to be
+    // remembered and not individual view settings per document)
+    int fileHistoryMaxRecent;
     // information about opened files (in most recently used order)
     Vec<FileState*>* fileStates;
     // state of the last session, usage depends on RestoreSession
@@ -623,6 +627,7 @@ static const FieldInfo gGlobalPrefsFields[] = {
     {offsetof(GlobalPrefs, treeFontSize), SettingType::Int, 0},
     {offsetof(GlobalPrefs, showStartPage), SettingType::Bool, true},
     {offsetof(GlobalPrefs, useTabs), SettingType::Bool, true},
+    {offsetof(GlobalPrefs, fileHistoryMaxRecent), SettingType::Int, 10},
     {(size_t)-1, SettingType::Comment, 0},
     {offsetof(GlobalPrefs, fileStates), SettingType::Array, (intptr_t)&gFileStateInfo},
     {offsetof(GlobalPrefs, sessionData), SettingType::Array, (intptr_t)&gSessionDataInfo},
@@ -634,13 +639,13 @@ static const FieldInfo gGlobalPrefsFields[] = {
      (intptr_t) "Settings after this line have not been recognized by the current version"},
 };
 static const StructInfo gGlobalPrefsInfo = {
-    sizeof(GlobalPrefs), 55, gGlobalPrefsFields,
+    sizeof(GlobalPrefs), 56, gGlobalPrefsFields,
     "\0\0MainWindowBackground\0EscToExit\0ReuseInstance\0UseSysColors\0RestoreSession\0TabWidth\0\0FixedPageUI\0EbookUI"
     "\0ComicBookUI\0ChmUI\0ExternalViewers\0ShowMenubar\0ReloadModifiedDocuments\0FullPathInTitle\0ZoomLevels\0ZoomIncr"
     "ement\0\0PrinterDefaults\0ForwardSearch\0AnnotationDefaults\0DefaultPasswords\0CustomScreenDPI\0\0RememberStatePer"
     "Document\0UiLanguage\0ShowToolbar\0ShowFavorites\0AssociatedExtensions\0AssociateSilently\0CheckForUpdates\0Versio"
     "nToSkip\0RememberOpenedFiles\0InverseSearchCmdLine\0EnableTeXEnhancements\0DefaultDisplayMode\0DefaultZoom\0Window"
-    "State\0WindowPos\0ShowToc\0SidebarDx\0TocDy\0TreeFontSize\0ShowStartPage\0UseTabs\0\0FileStates\0SessionData\0Reop"
-    "enOnce\0TimeOfLastUpdateCheck\0OpenCountWeek\0\0"};
+    "State\0WindowPos\0ShowToc\0SidebarDx\0TocDy\0TreeFontSize\0ShowStartPage\0UseTabs\0FileHistoryMaxRecent\0\0FileSta"
+    "tes\0SessionData\0ReopenOnce\0TimeOfLastUpdateCheck\0OpenCountWeek\0\0"};
 
 #endif

--- a/src/SumatraStartup.cpp
+++ b/src/SumatraStartup.cpp
@@ -106,9 +106,13 @@ static FileExistenceChecker* gFileExistenceChecker = nullptr;
 
 void FileExistenceChecker::GetFilePathsToCheck() {
     DisplayState* state;
-    for (size_t i = 0; i < 2 * FILE_HISTORY_MAX_RECENT && (state = gFileHistory.Get(i)) != nullptr; i++) {
-        if (!state->isMissing) {
-            paths.Append(str::Dup(state->filePath));
+    if (gGlobalPrefs->fileHistoryMaxRecent > 0) {
+        for (size_t i = 0; i < 2 * static_cast<size_t>(gGlobalPrefs->fileHistoryMaxRecent) &&
+                           (state = gFileHistory.Get(i)) != nullptr;
+             i++) {
+            if (!state->isMissing) {
+                paths.Append(str::Dup(state->filePath));
+            }
         }
     }
     // add missing paths from the list of most frequently opened documents

--- a/website/settings/settings3.3.html
+++ b/website/settings/settings3.3.html
@@ -298,7 +298,12 @@ ShowStartPage = true
 
 <span class="cm" id="UseTabs">if true, documents are opened in tabs instead of new windows (introduced in version 3.0)</span>
 UseTabs = true
-
+<div>
+<span class="cm" id="FileHistoryMaxRecent">number of most recently used files that will be shown in the menu (and remembered in the preferences
+file, if just filenames are to be remembered and not individual view settings per document)
+(introduced in version 3.3)</span>
+FileHistoryMaxRecent = 10
+</div>
 <span class="cm" id="FileStates">information about opened files (in most recently used order)</span>
 FileStates [
   [


### PR DESCRIPTION
I do not find 10 recently used files to be nearly enough so I've made the number configurable through SumatraPDF-settings.txt.