### PR TITLE
Fix zoom value jump when at ZOOM_MAX or ZOOM_MIN

### DIFF
--- a/src/DisplayModel.cpp
+++ b/src/DisplayModel.cpp
@@ -1591,7 +1591,7 @@ float DisplayModel::GetNextZoomStep(float towardsLevel) const {
 
     const float FUZZ = 0.01f;
     float newZoom = towardsLevel;
-    if (currZoom < towardsLevel) {
+    if (currZoom + FUZZ < towardsLevel) {
         for (size_t i = 0; i < zoomLevels->size(); i++) {
             if (zoomLevels->at(i) - FUZZ > currZoom) {
                 newZoom = zoomLevels->at(i);
@@ -1603,7 +1603,7 @@ float DisplayModel::GetNextZoomStep(float towardsLevel) const {
         } else if (currZoom + FUZZ < widthZoom && widthZoom < newZoom - FUZZ) {
             newZoom = ZOOM_FIT_WIDTH;
         }
-    } else if (currZoom > towardsLevel) {
+    } else if (currZoom - FUZZ > towardsLevel) {
         for (size_t i = zoomLevels->size(); i > 0; i--) {
             if (zoomLevels->at(i - 1) + FUZZ < currZoom) {
                 newZoom = zoomLevels->at(i - 1);


### PR DESCRIPTION
Addresses issue #1891. When within FUZZ distance of limit values, don't zoom.

I am not sure if this is the optimal solution to this problem and whether constant FUZZ should be used in this manner but zoom still works and the annoying problem is gone.