### PR TITLE
Add faster scrolling if the cursor is over the scroll bar

### DIFF
--- a/src/Canvas.cpp
+++ b/src/Canvas.cpp
@@ -1109,6 +1109,16 @@ static LRESULT CanvasOnMouseWheel(WindowInfo* win, UINT msg, WPARAM wp, LPARAM l
         return 0;
     }
 
+    // scroll faster if the cursor is over the scroll bar
+    if(IsCursorOverWindow(win->hwndCanvas)) {
+        Point pt;
+        GetCursorPosInHwnd(win->hwndCanvas, pt);
+        if (pt.x > win->canvasRc.dx) {
+            SendMessageW(win->hwndCanvas, WM_VSCROLL, (delta > 0) ? SB_HPAGEUP : SB_HPAGEDOWN, 0);
+            return 0;
+        }
+    }
+
     win->wheelAccumDelta += delta;
     int currentScrollPos = GetScrollPos(win->hwndCanvas, SB_VERT);
 


### PR DESCRIPTION
If the cursor is over the scroll bar, scrolling with the mouse wheel will be faster.
Currently implemented with the same speed as if you were holding the alt button.
It's a feature I use a lot in other programs so I thought it could be useful.