### PR TITLE
Implement "fit content" zoom for images

### DIFF
--- a/src/Canvas.cpp
+++ b/src/Canvas.cpp
@@ -1215,17 +1215,16 @@ static LRESULT OnGesture(WindowInfo* win, UINT msg, WPARAM wp, LPARAM lp) {
                 // in which case we want to pan/scroll the document
                 bool isFlick = (gi.dwFlags & GF_INERTIA) && abs(deltaX) > abs(deltaY);
                 DisplayModel* dm = win->AsFixed();
-                bool enableFlick = !dm || !dm->NeedHScroll();
+                bool enableFlick = !dm || !dm->NeedHScroll() || abs(deltaX) > 25;
                 if (isFlick && enableFlick) {
                     if (deltaX < 0) {
                         win->ctrl->GoToPrevPage();
                     } else if (deltaX > 0) {
                         win->ctrl->GoToNextPage();
                     }
-                    // When we switch pages, go back to the initial scroll position
-                    // and prevent further pan movement caused by the inertia
+                    // When we switch pages prevent further pan movement caused by the inertia
                     if (dm) {
-                        dm->ScrollXTo(win->touchState.panScrollOrigX);
+                        dm->ScrollXBy(0);
                     }
                     win->touchState.panStarted = false;
                 } else if (dm) {

--- a/src/Canvas.cpp
+++ b/src/Canvas.cpp
@@ -1211,11 +1211,10 @@ static LRESULT OnGesture(WindowInfo* win, UINT msg, WPARAM wp, LPARAM lp) {
                 win->touchState.panPos = gi.ptsLocation;
 
                 // on left / right flick, go to next / prev page
-                // unless this is PDF and horizontal scrollbar is visible,
-                // in which case we want to pan/scroll the document
+                // unless we can pan/scroll the document
                 bool isFlick = (gi.dwFlags & GF_INERTIA) && abs(deltaX) > abs(deltaY);
                 DisplayModel* dm = win->AsFixed();
-                bool enableFlick = !dm || !dm->NeedHScroll() || abs(deltaX) > 25;
+                bool enableFlick = !dm || !dm->NeedHScroll() || (deltaX > 0 && !dm->CanScrollRight()) || (deltaX < 0 && !dm->CanScrollLeft());
                 if (isFlick && enableFlick) {
                     if (deltaX < 0) {
                         win->ctrl->GoToPrevPage();

--- a/src/DisplayModel.cpp
+++ b/src/DisplayModel.cpp
@@ -186,6 +186,14 @@ bool DisplayModel::NeedVScroll() const {
     return viewPort.dy < canvasSize.dy;
 }
 
+bool DisplayModel::CanScrollRight() const {
+    return viewPort.x + viewPort.dx < canvasSize.dx;
+}
+
+bool DisplayModel::CanScrollLeft() const {
+    return viewPort.x > 0;
+}
+
 Size DisplayModel::GetCanvasSize() const {
     return canvasSize;
 }

--- a/src/DisplayModel.h
+++ b/src/DisplayModel.h
@@ -141,6 +141,8 @@ struct DisplayModel : Controller {
     [[nodiscard]] bool IsVScrollbarVisible() const;
     [[nodiscard]] bool NeedHScroll() const;
     [[nodiscard]] bool NeedVScroll() const;
+    [[nodiscard]] bool CanScrollRight() const;;
+    [[nodiscard]] bool CanScrollLeft() const;;
     [[nodiscard]] Size GetCanvasSize() const;
 
     [[nodiscard]] bool PageShown(int pageNo) const;

--- a/src/EngineImages.cpp
+++ b/src/EngineImages.cpp
@@ -197,7 +197,7 @@ RenderedBitmap* EngineImages::RenderPage(RenderPageArgs& args) {
     Rect pageRcI = PageMediabox(pageNo).Round();
     ImageAttributes imgAttrs;
     imgAttrs.SetWrapMode(WrapModeTileFlipXY);
-    Status ok = g.DrawImage(page->bmp, ToGdipRect(pageRcI), 0, 0, pageRcI.dx, pageRcI.dy, UnitPixel, &imgAttrs);
+    Status ok = g.DrawImage(page->bmp, ToGdipRect(pageRcI), pageRcI.x, pageRcI.y, pageRcI.dx, pageRcI.dy, UnitPixel, &imgAttrs);
 
     DropPage(page, false);
     DeleteDC(hDC);

--- a/src/EngineImages.cpp
+++ b/src/EngineImages.cpp
@@ -375,9 +375,10 @@ RectF EngineImages::PageContentBox(int pageNo, RenderTarget target) {
     auto page = GetPage(pageNo, true);
     if (!page)
         return RectF{};
+    defer {
+        DropPage(page, false);
+    };
 
-    // if we loaded bitmap, it might get deleted by GetPage while we are accessing it, so lock it
-    ScopedCritSec scope(&cacheAccess);
     auto bmp = page->bmp;
     if (!bmp)
         return RectF{};

--- a/src/EngineImages.cpp
+++ b/src/EngineImages.cpp
@@ -412,7 +412,7 @@ RectF EngineImages::PageContentBox(int pageNo, RenderTarget target) {
     }
 
     auto getPixel = [&bmpData, bytesPerPixel](int x, int y) -> uint32_t {
-        CrashIf(x < 0 || x >= bmpData.Width || y < 0 || y >= bmpData.Height);
+        CrashIf(x < 0 || x >= (int)bmpData.Width || y < 0 || y >= (int)bmpData.Height);
         auto data = static_cast<const uint8_t*>(bmpData.Scan0);
         unsigned idx = bytesPerPixel * x + bmpData.Stride * y;
         return (data[idx+2] << 16) | (data[idx+1] << 8) | data[idx];


### PR DESCRIPTION
It works by scanning edges of a bitmap of an image and removing regions of similar colors from "page content box". Very useful for cropping page margins while reading manga or comic books.
Also included a patch which makes flicks on touchscreen work again while zoomed in.