### PR TITLE
Fix #1553 - color bug in "Page:" and "Find:" toolbar labels

### DIFF
--- a/src/SumatraPDF.cpp
+++ b/src/SumatraPDF.cpp
@@ -2097,7 +2097,7 @@ enum class SaveChoice {
 SaveChoice ShouldSaveAnnotationsDialog(HWND hwndParent, const WCHAR* filePath) {
     auto fileName = path::GetBaseNameTemp(filePath);
     auto mainInstr = str::Format(_TR("Unsaved annotations in '%s'"), fileName);
-    auto content = _TR("Save annoations?");
+    auto content = _TR("Save annotations?");
 
     constexpr int kBtnIdDiscard = 100;
     constexpr int kBtnIdSaveToExisting = 101;

--- a/src/Toolbar.cpp
+++ b/src/Toolbar.cpp
@@ -296,7 +296,8 @@ static LRESULT CALLBACK WndProcToolbar(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp
             // SetBkMode(hdc, TRANSPARENT);
             auto br = CreateSolidBrush(GetCurrentTheme()->mainWindow.backgroundColor);
 #else
-            auto col = GetAppColor(AppColor::DocumentText);
+            // Set color used in "Page:" and "Find:" labels to black
+            auto col = RGB(0x00, 0x00, 0x00);
             SetTextColor(hdc, col);
             SetBkMode(hdc, TRANSPARENT);
             auto br = GetStockBrush(NULL_BRUSH);


### PR DESCRIPTION
Also, fixed a typo.