### PR TITLE
select first annotation when delete

### DIFF
--- a/src/EditAnnotations.cpp
+++ b/src/EditAnnotations.cpp
@@ -830,7 +830,9 @@ void DeleteAnnotationAndUpdateUI(TabInfo* tab, EditAnnotationsWindow* ew, Annota
     if (ew != nullptr) {
         // can be null if called from Menu.cpp and annotations window is not visible
         RebuildAnnotations(ew);
-        UpdateUIForSelectedAnnotation(ew, -1);
+        UpdateUIForSelectedAnnotation(ew, 0);
+        ew->listBox->SetCurrentSelection(0);
+
     }
     WindowInfoRerender(tab->win);
     ToolbarUpdateStateForWindow(tab->win, false);


### PR DESCRIPTION
when delete an annotation each time, the delete button will disappear, you need to re-select an annotation to delete.
this PR will select the first annotation of the remaining, you can continue to press delete button till all annotations are deleted.