### PR TITLE
Support lazyload when restore session

### DIFF
--- a/src/Settings.h
+++ b/src/Settings.h
@@ -329,6 +329,8 @@ struct GlobalPrefs {
     // if true and SessionData isn't empty, that session will be restored
     // at startup
     bool restoreSession;
+    // if true, lazyload session tabs on startup
+    bool lazyloadWhenRestore;
     // ISO code of the current UI language
     char* uiLanguage;
     // pattern used to launch the LaTeX editor when doing inverse search
@@ -645,6 +647,7 @@ static const FieldInfo gGlobalPrefsFields[] = {
     {offsetof(GlobalPrefs, rememberOpenedFiles), SettingType::Bool, true},
     {offsetof(GlobalPrefs, rememberStatePerDocument), SettingType::Bool, true},
     {offsetof(GlobalPrefs, restoreSession), SettingType::Bool, true},
+    {offsetof(GlobalPrefs, lazyloadWhenRestore), SettingType::Bool, true},
     {offsetof(GlobalPrefs, uiLanguage), SettingType::String, 0},
     {offsetof(GlobalPrefs, inverseSearchCmdLine), SettingType::String, 0},
     {offsetof(GlobalPrefs, enableTeXEnhancements), SettingType::Bool, false},
@@ -686,12 +689,12 @@ static const FieldInfo gGlobalPrefsFields[] = {
 };
 static const StructInfo gGlobalPrefsInfo = {
     sizeof(GlobalPrefs), 57, gGlobalPrefsFields,
-    "\0FixedPageUI\0ComicBookUI\0ChmUI\0\0SelectionHandlers\0ExternalViewers\0\0ZoomLevels\0ZoomIncrement\0\0PrinterDef"
-    "aults\0ForwardSearch\0Annotations\0DefaultPasswords\0\0RememberOpenedFiles\0RememberStatePerDocument\0RestoreSessi"
-    "on\0UiLanguage\0InverseSearchCmdLine\0EnableTeXEnhancements\0DefaultDisplayMode\0DefaultZoom\0Shortcuts\0EscToExit"
+    "\0FixedPageUI\0ComicBookUI\0ChmUI\0\0SelectionHandlers\0ExternalViewers\0\0ZoomLevels\0ZoomIncrement\0\0PrinterDefaults"
+    "\0ForwardSearch\0Annotations\0DefaultPasswords\0\0RememberOpenedFiles\0RememberStatePerDocument\0RestoreSession\0LazyloadWhenRestore"
+    "\0UiLanguage\0InverseSearchCmdLine\0EnableTeXEnhancements\0DefaultDisplayMode\0DefaultZoom\0Shortcuts\0EscToExitavorites"
     "\0ReuseInstance\0ReloadModifiedDocuments\0\0MainWindowBackground\0FullPathInTitle\0ShowMenubar\0ShowToolbar\0ShowF"
-    "avorites\0ShowToc\0TocDy\0SidebarDx\0ToolbarSize\0TabWidth\0TreeFontSize\0SmoothScroll\0ShowStartPage\0CheckForUpd"
-    "ates\0VersionToSkip\0WindowState\0WindowPos\0UseTabs\0UseSysColors\0CustomScreenDPI\0\0FileStates\0SessionData\0Re"
-    "openOnce\0TimeOfLastUpdateCheck\0OpenCountWeek\0\0"};
+    "\0ShowToc\0TocDy\0SidebarDx\0ToolbarSize\0TabWidth\0TreeFontSize\0SmoothScroll\0ShowStartPage\0CheckForUpdates"
+    "\0VersionToSkip\0WindowState\0WindowPos\0UseTabs\0UseSysColors\0CustomScreenDPI\0\0FileStates\0SessionData\0ReopenOnce"
+    "\0TimeOfLastUpdateCheck\0OpenCountWeek\0\0"};
 
 #endif

--- a/src/SumatraPDF.h
+++ b/src/SumatraPDF.h
@@ -169,7 +169,7 @@ struct LoadArgs {
     bool noSavePrefs = false;
 };
 
-WindowInfo* LoadDocument(LoadArgs& args);
+WindowInfo* LoadDocument(LoadArgs& args, bool lazyload = false);
 WindowInfo* CreateAndShowWindowInfo(SessionData* data = nullptr);
 
 uint MbRtlReadingMaybe();

--- a/src/SumatraStartup.cpp
+++ b/src/SumatraStartup.cpp
@@ -301,10 +301,10 @@ static WindowInfo* LoadOnStartup(const WCHAR* filePath, const Flags& flags, bool
     return win;
 }
 
-static void RestoreTabOnStartup(WindowInfo* win, TabState* state) {
+static void RestoreTabOnStartup(WindowInfo* win, TabState* state, bool lazyload=true) {
     LoadArgs args(state->filePath, win);
     args.noSavePrefs = true;
-    if (!LoadDocument(args)) {
+    if (!LoadDocument(args, lazyload)) {
         return;
     }
     TabInfo* tab = win->currentTab;
@@ -1240,9 +1240,12 @@ ContinueOpenWindow:
                 // the current fix is to not call prefs::Save() below but maybe there's a better way
                 // maybe make a copy of TabState so that it isn't invalidated
                 // https://github.com/sumatrapdfreader/sumatrapdf/issues/1674
-                RestoreTabOnStartup(win, state);
+                RestoreTabOnStartup(win, state, gGlobalPrefs->lazyloadWhenRestore);
             }
             TabsSelect(win, data->tabIndex - 1);
+            if (gGlobalPrefs->lazyloadWhenRestore) {
+                ReloadDocument(win, false);
+            }
         }
     }
     ResetSessionState(gGlobalPrefs->sessionData);


### PR DESCRIPTION
Lazy load session tabs when startup untill switch to the target tab for lower mem usage and speed up.

When select other tabs, there will be a highlight message "Please wait - rendering..." before the document is loaded (using ReloadDocument).

User may change lazyloadWhenRestore setting to disable it.

In the future we may add scheduled load in background (but will increase mem usage so better make it optional) #2565, or add a DisplayModel with lazyload support for better code structure.

#1497