### PR TITLE
support lazyload (next )

### DIFF
--- a/src/Settings.h
+++ b/src/Settings.h
@@ -287,6 +287,9 @@ struct SessionData {
     int sidebarDx;
 };
 
+// if true, Enable lazyload session tabs on startup
+static bool gEnableLazyLoad = true;
+
 // Most values on this structure can be updated through the UI and are
 // persisted in SumatraPDF-settings.txt
 struct GlobalPrefs {

--- a/src/SumatraPDF.h
+++ b/src/SumatraPDF.h
@@ -165,7 +165,7 @@ struct LoadArgs {
     AutoFreeStr fileName;
 };
 
-WindowInfo* LoadDocument(LoadArgs& args);
+WindowInfo* LoadDocument(LoadArgs& args, bool lazyload = false);
 WindowInfo* CreateAndShowWindowInfo(SessionData* data = nullptr);
 
 uint MbRtlReadingMaybe();

--- a/src/SumatraStartup.cpp
+++ b/src/SumatraStartup.cpp
@@ -301,10 +301,10 @@ static WindowInfo* LoadOnStartup(const char* filePath, const Flags& flags, bool 
     return win;
 }
 
-static void RestoreTabOnStartup(WindowInfo* win, TabState* state) {
+static void RestoreTabOnStartup(WindowInfo* win, TabState* state, bool lazyload=true) {
     LoadArgs args(state->filePath, win);
     args.noSavePrefs = true;
-    if (!LoadDocument(args)) {
+    if (!LoadDocument(args, lazyload)) {
         return;
     }
     TabInfo* tab = win->currentTab;
@@ -1269,9 +1269,12 @@ ContinueOpenWindow:
                 // the current fix is to not call prefs::Save() below but maybe there's a better way
                 // maybe make a copy of TabState so that it isn't invalidated
                 // https://github.com/sumatrapdfreader/sumatrapdf/issues/1674
-                RestoreTabOnStartup(win, state);
+                RestoreTabOnStartup(win, state, gEnableLazyLoad);
             }
             TabsSelect(win, data->tabIndex - 1);
+            if (gEnableLazyLoad) {
+                ReloadDocument(win, false);
+            }
         }
     }
     ResetSessionState(gGlobalPrefs->sessionData);


### PR DESCRIPTION
>Lazy load session tabs when startup untill switch to the target tab for lower mem usage and speed up.
>
>When select other tabs, there will be a highlight message "Please wait - rendering..." before the document is loaded (using ReloadDocument).

#2590
Rebase on next branch.
~User may change lazyloadWhenRestore setting to disable it.~
Add a global variable static bool gEnableLazyLoad = true in settings.h

>In the future we may add scheduled load in background (but will increase mem usage so better make it optional) #2565, or add a DisplayModel with lazyload support for better code structure.
>
>#1497

Still, it will be nice to move all loading to be async, for more fluent loading UX, but I wish there could be another setting to select whether we need load all tabs, or only load when necessary (like this ver.). 

And one step further we may oneday support to freeze some tabs to constrain mem usage like Chromes, a not so necessary feature lol.