### PR TITLE
Fix overlapped rendering of tabs

### DIFF
--- a/src/wingui/WinGui.cpp
+++ b/src/wingui/WinGui.cpp
@@ -3291,10 +3291,6 @@ void TabsCtrl::Layout() {
     }
     auto maxDx = (rect.dx - 5) / nTabs;
     int dx = std::min(tabDefaultDx, maxDx);
-    dx--;
-    if (tabSize.dx == dx && tabSize.dy == dy) {
-        return;
-    }
     tabSize = {dx, dy};
     //logfa("TabsCtrl::Layout size: (%d, %d), tab size: (%d, %d)\n", rect.dx, rect.dy, tabSize.dx, tabSize.dy);
 


### PR DESCRIPTION
When the window width was stable and tabs were removed/closed and
opened, the new tabs were rendered in an overlapped way. Fix this by
doing the layout of the tabs in such a case.

Issue # 2806