### PR TITLE
Support non-HTTP selection handler

### DIFF
--- a/src/SumatraPDF.cpp
+++ b/src/SumatraPDF.cpp
@@ -4675,7 +4675,7 @@ static LRESULT FrameOnCommand(MainWindow* win, HWND hwnd, UINT msg, WPARAM wp, L
         ReportIf(!selectedSH);
         WCHAR* url = ToWstrTemp(selectedSH->url);
         // try to auto-fix url
-        bool isValidURL = str::StartsWithI(url, L"http://") || str::StartsWithI(url, L"https://");
+        bool isValidURL = str::Find(url, L"://") != nullptr;
         if (!isValidURL) {
             url = str::JoinTemp(L"https://", url);
         }


### PR DESCRIPTION
Currently, `SelectionHandlers` only support http(s) URL. Some dictionary apps could query words using URL scheme like `goldendict://` or `eudic://`. It would be useful to support not only http(s).

Tested with following settings:
```
SelectionHandlers [
  [
    URL = goldendict://${selection}
    Name = &GoldenDict
  ]
  [
    URL = duckduckgo.com/?ia=web&q=${selection}
    Name = &DuckDuckGoNoProtocol
  ]
  [
    URL = https://duckduckgo.com/?ia=web&q=${selection}
    Name = &DuckDuckGo
  ]
]
```