### PR TITLE
Added command line option to disable auto rotation when PDF is not in portrait mode

### DIFF
--- a/src/Flags.cpp
+++ b/src/Flags.cpp
@@ -527,7 +527,7 @@ void ParseFlags(const WCHAR* cmdLine, Flags& i) {
         }
         if (arg == Arg::PrintSettings) {
             // argument is a comma separated list of page ranges and
-            // advanced options [even|odd], [noscale|shrink|fit] and [autorotation|portrait|landscape]
+            // advanced options [even|odd], [noscale|shrink|fit] and [autorotation|portrait|landscape] and disable-auto-rotation
             // e.g. -print-settings "1-3,5,10-8,odd,fit"
             i.printSettings = str::Dup(param);
             str::RemoveCharsInPlace(i.printSettings, " ");

--- a/src/Print.cpp
+++ b/src/Print.cpp
@@ -470,8 +470,8 @@ static bool PrintToDevice(const PrintData& pd) {
 
             SizeF pSize = engine.PageMediabox(pageNo).Size();
             int rotation = 0;
-            // Turn the document by 90 deg if it isn't in portrait mode
-            if (pSize.dx > pSize.dy) {
+            // Turn the document by 90 deg if it isn't in portrait mode & if autoRotation is not disabled
+            if (pd.advData.autoRotate && pSize.dx > pSize.dy) {
                 rotation += 90;
                 std::swap(pSize.dx, pSize.dy);
             }
@@ -1120,6 +1120,8 @@ static void ApplyPrintSettings(Printer* printer, const char* settings, int pageC
             advanced.rotation = PrintRotationAdv::Portrait;
         } else if (str::EqI(s, "landscape")) {
             advanced.rotation = PrintRotationAdv::Landscape;
+        } else if (str::EqI(s, "disable-auto-rotation")) {
+            advanced.autoRotate = false;
         } else if (str::Parse(s, "%dx%$", &val) && 0 < val && val < 1000) {
             devMode->dmCopies = (short)val;
             devMode->dmFields |= DM_COPIES;

--- a/src/SumatraDialogs.h
+++ b/src/SumatraDialogs.h
@@ -20,10 +20,11 @@ struct Print_Advanced_Data {
     PrintRangeAdv range;
     PrintScaleAdv scale;
     PrintRotationAdv rotation;
+    bool autoRotate;
 
     explicit Print_Advanced_Data(PrintRangeAdv range = PrintRangeAdv::All, PrintScaleAdv scale = PrintScaleAdv::Shrink,
-                                 PrintRotationAdv rotation = PrintRotationAdv::Auto)
-        : range(range), scale(scale), rotation(rotation) {
+                                 PrintRotationAdv rotation = PrintRotationAdv::Auto, bool autoRotate = true)
+        : range(range), scale(scale), rotation(rotation), autoRotate(autoRotate) {
     }
 };
 


### PR DESCRIPTION
Adds a new argument `disable-auto-rotation` to override auto rotation when the PDF is not in portrait mode & gives preference to the user specified orientation.

Fixes #3073 - We get this issue when we are trying to print a portrait 6" X 4" PDF in landscape mode.