### PR TITLE
Fix spelling error of "directory" in translations

### DIFF
--- a/src/docs/translations.txt
+++ b/src/docs/translations.txt
@@ -13224,7 +13224,7 @@ br:Abrir Pasta em Directory &Opus
 cy:Agor Cyfeiriadur yn Directory &Opus
 de:Verzeichnis in Directory &Opus öffnen
 it:Apri cartella in Directory &Opus
-nl:Open Map in Direcotry &Opus
+nl:Open Map in Directory &Opus
 pl:Otwórz katalog w Directory &Opus
 :Open Embedded PDF
 am:Բացել ներկառուցված PDF-ը

--- a/src/docs/translations.txt
+++ b/src/docs/translations.txt
@@ -13219,7 +13219,7 @@ de:Verzeichnis in &Total Commander öffnen
 it:Apri cartella in &Total Commander
 nl:Open Map in &TotalCommander
 pl:Otwórz katalog w &Total Commanderze
-:Open Directory in Direcotry &Opus
+:Open Directory in Directory &Opus
 br:Abrir Pasta em Directory &Opus
 cy:Agor Cyfeiriadur yn Directory &Opus
 de:Verzeichnis in Directory &Opus öffnen


### PR DESCRIPTION
I found a small typo in translations.txt while reading the latest changes of the SumatraPDF source code.