### PR TITLE
Increase Max Copies when Printing

### DIFF
--- a/src/Print.cpp
+++ b/src/Print.cpp
@@ -1122,7 +1122,7 @@ static void ApplyPrintSettings(Printer* printer, const char* settings, int pageC
             advanced.rotation = PrintRotationAdv::Landscape;
         } else if (str::EqI(s, "disable-auto-rotation")) {
             advanced.autoRotate = false;
-        } else if (str::Parse(s, "%dx%$", &val) && 0 < val && val < 1000) {
+        } else if (str::Parse(s, "%dx%$", &val) && 0 < val && val < 10000) {
             devMode->dmCopies = (short)val;
             devMode->dmFields |= DM_COPIES;
         } else if (str::EqI(s, "simplex")) {


### PR DESCRIPTION
When printing a PDF, increase the maximum number of copies from 999 to 9999. Currently anything over 1000 will revert back to 1 copy. I would like to have the option to queue up more than 1000 at a single time. I tested and this works for my purposes going up to a max of 9999 copies.

`SumatraPDF-prerel-64.exe -print-to "PrinterXYZ" -print-settings "9999x" -silent file.pdf`
