### PR TITLE
Fix dragging tabs within one window

### DIFF
--- a/src/wingui/WinGui.cpp
+++ b/src/wingui/WinGui.cpp
@@ -3541,6 +3541,7 @@ static void UpdateAfterDrag(TabsCtrl* tabsCtrl, int tab1, int tab2) {
         newSelected = tab2;
     }
     tabsCtrl->SetSelected(newSelected);
+    tabsCtrl->Layout();
 }
 
 LRESULT TabsCtrl::OnNotifyReflect(WPARAM wp, LPARAM lp) {
@@ -3661,7 +3662,6 @@ LRESULT TabsCtrl::WndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
                     }
                     SetSelected(tabUnderMouse);
                     TriggerSelectionChanged(this);
-                    return 0;
                 }
                 SetCapture(hwnd);
             }


### PR DESCRIPTION
1. call Layout() after swapping tabs. The tabs retained their layout rectangles without this. So suppose I drag tab 2 into the position of tab 1, they're swapped, but when a new mouse message comes in, the original tab 1, now tab 2, still thinks it's within its rectangle, so we immediately and erroneously swap 1 with 2 again. This furious double-swapping continues without user-visible changes.

2. When selecting a tab with a click, don't return early; start the capture just as if I clicked on a selected tab, to allow dragging.

Fixes #3067.