### PR TITLE
When dragged to a different window and released, add tab to that window

### DIFF
--- a/src/wingui/WinGui.cpp
+++ b/src/wingui/WinGui.cpp
@@ -3768,7 +3768,10 @@ LRESULT TabsCtrl::WndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
                     UpdateAfterDrag(this, selectedTab, tabUnderMouse);
                 } else if (tabUnderMouse == -1) {
                     // migrate to new/different window
-                    TriggerTabMigration(this, selectedTab, mousePos);
+                    POINT p(mousePos.x, mousePos.y);
+                    ClientToScreen(hwnd, &p);
+                    Point scPoint(p.x, p.y);
+                    TriggerTabMigration(this, selectedTab, scPoint);
                 }
             }
             return 0;


### PR DESCRIPTION
The change from ReloadDocument() to LoadDocument() is because the former checks assumptions on win->ctrl and tab->ctrl that aren't true in our novel use case. And anyway, LoadDocument with args->reuseTab is exactly the right thing to do in our case; and is what ReloadDocument() would have done if we hackily adjusted win->ctrl=nullptr for it.