### PR TITLE
Don't do WM_MOUSEMOVE processing on WM_MOUSELEAVE, prevent crashes

### DIFF
--- a/src/wingui/WinGui.cpp
+++ b/src/wingui/WinGui.cpp
@@ -3676,7 +3676,7 @@ LRESULT TabsCtrl::WndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
 
         case WM_MOUSELEAVE:
             // logfa("TabsCtrl::WndProc: WM_MOUSELEAVE\n");
-            [[fallthrough]];
+            break;
 
         case WM_MOUSEMOVE: {
             bool isDragging = (GetCapture() == hwnd);


### PR DESCRIPTION
There's a crash in UpdateAfterDrag() with the current dragging code, and I found a way to reliably trigger it: right click on a tab for context menu, then move the mouse a bit still staying in the tab, and left click. What's happening is that the window gets a WM_MOUSELEAVE message it's previously asked for, and falls through to WM_MOUSEMOVE; but since in the beginning of WndProc() WM_MOUSELEAVE hardcoded mousePos to (-1,-1), this effectively sets tabHighlighted=-1, which is semantically wrong. Any tiny WM_MOUSEMOVE later while under left-click will then crash on assert, because it'll try to "swap" tabs -1 and current.

I'm not sure why WM_MOUSELEAVE was deliberately coded to fallthrough to WM_MOUSEMOVE; maybe the idea was to track the mouse leaving the window, for dragging a tab out? But turns out WM_MOUSELEAVE just means the pointer left a tiny "hover" area where it was staying, and seemingly nothing important needs to happen because of that. We don't need it to track actual movement, WM_MOUSEMOVE messages are still coming anyway, and while dragging they'll continue to come because of SetCapture().

It's possible I missed something and this way of fixing the crash is not correct. It's always possible to explicitly check tabHightlighted!=-1 before trying to swap tabs in WM_MOUSEMOVE. That'll also prevent the crash but I preferred to get at the root and prevent setting tabHighlighted=-1 wrongly.