### PR TITLE
Improve middle button closing of tabs

### DIFF
--- a/src/wingui/WinGui.cpp
+++ b/src/wingui/WinGui.cpp
@@ -3722,9 +3722,6 @@ LRESULT TabsCtrl::WndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
                 HwndScheduleRepaint(hwnd);
                 tabHighlightedClose = xHl;
             }
-            if (!overClose) {
-                tabBeingClosed = -1;
-            }
             return 0;
         }
 
@@ -3753,7 +3750,8 @@ LRESULT TabsCtrl::WndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
         }
 
         case WM_LBUTTONUP: {
-            if (tabBeingClosed != -1) {
+            if (tabBeingClosed != -1 && tabUnderMouse == tabBeingClosed
+                && overClose) {
                 // send notification that the tab is closed
                 TriggerTabClosed(this, tabBeingClosed);
                 HwndScheduleRepaint(hwnd);


### PR DESCRIPTION
Middle button closing of tabs is flaky b/c even a slight movement between press and release causes tabBeingClosed=-1 in WM_MOUSEMOVE. That's meant for canceling a left-button close when we move away from X before releasing, but it also affects middle-button badly. Remove that and instead check more stringently when left button releases. This restores middle button to its glory and as a bonus when we left-press, move away then come back to the X then release, the tab closes after all - the normal Windows behavior.