### PR TITLE
Move Document colors from AppColors to theme.

### DIFF
--- a/src/AppColors.cpp
+++ b/src/AppColors.cpp
@@ -84,9 +84,6 @@ static COLORREF GetNoDocBgColor() {
 }
 
 COLORREF GetAppColor(AppColor col) {
-    COLORREF c;
-    ParsedColor* parsedCol;
-
     if (col == AppColor::NoDocBg) {
         // GetCurrentTheme()->document.canvasColor
         return GetNoDocBgColor();
@@ -113,51 +110,6 @@ COLORREF GetAppColor(AppColor col) {
         return COL_BLUE_LINK;
     }
 
-    if (col == AppColor::DocumentBg) {
-        if (gGlobalPrefs->useSysColors) {
-            if (gGlobalPrefs->fixedPageUI.invertColors) {
-                c = GetSysColor(COLOR_WINDOWTEXT);
-            } else {
-                c = GetSysColor(COLOR_WINDOW);
-            }
-            return c;
-        }
-        // ParsedColor* bgParsed = GetPrefsColor(gGlobalPrefs->mainWindowBackground);
-        if (gGlobalPrefs->fixedPageUI.invertColors) {
-            parsedCol = GetPrefsColor(gGlobalPrefs->fixedPageUI.textColor);
-        } else {
-            parsedCol = GetPrefsColor(gGlobalPrefs->fixedPageUI.backgroundColor);
-        }
-        return parsedCol->col;
-    }
-
-    if (col == AppColor::DocumentText) {
-        if (gGlobalPrefs->useSysColors) {
-            if (gGlobalPrefs->fixedPageUI.invertColors) {
-                c = GetSysColor(COLOR_WINDOW);
-            } else {
-                c = GetSysColor(COLOR_WINDOWTEXT);
-            }
-            return c;
-        }
-
-        if (gGlobalPrefs->fixedPageUI.invertColors) {
-            parsedCol = GetPrefsColor(gGlobalPrefs->fixedPageUI.backgroundColor);
-        } else {
-            parsedCol = GetPrefsColor(gGlobalPrefs->fixedPageUI.textColor);
-        }
-        return parsedCol->col;
-    }
-
     CrashIf(true);
     return COL_WINDOW_BG;
-}
-
-void GetFixedPageUiColors(COLORREF& text, COLORREF& bg) {
-#if 0
-    text = GetCurrentTheme()->document.textColor;
-    bg = GetCurrentTheme()->document.backgroundColor;
-#endif
-    text = GetAppColor(AppColor::DocumentText);
-    bg = GetAppColor(AppColor::DocumentBg);
 }

--- a/src/AppColors.h
+++ b/src/AppColors.h
@@ -15,10 +15,7 @@ enum class AppColor {
     MainWindowText,
     MainWindowLink,
 
-    DocumentBg,
-    DocumentText,
-
 };
 
 COLORREF GetAppColor(AppColor);
-void GetFixedPageUiColors(COLORREF& text, COLORREF& bg);
+

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -41,6 +41,7 @@
 #include "StressTesting.h"
 #include "Translations.h"
 #include "uia/Provider.h"
+#include "Theme.h"
 
 #include "utils/Log.h"
 
@@ -618,8 +619,10 @@ void LinkHandler::GotoNamedDest(const char* name) {
 void UpdateTreeCtrlColors(MainWindow* win) {
     COLORREF labelBgCol = GetSysColor(COLOR_BTNFACE);
     COLORREF labelTxtCol = GetSysColor(COLOR_BTNTEXT);
-    COLORREF treeBgCol = GetAppColor(AppColor::DocumentBg);
-    COLORREF treeTxtCol = GetAppColor(AppColor::DocumentText);
+    COLORREF treeBgCol, treeTxtCol;
+    GetDocumentColors(treeTxtCol, treeBgCol);
+    logfa("retrieved doc colors in tree control: 0x%x 0x%x\n", treeTxtCol, treeBgCol);
+
     COLORREF splitterCol = GetSysColor(COLOR_BTNFACE);
     bool flatTreeWnd = false;
 

--- a/src/SumatraPDF.cpp
+++ b/src/SumatraPDF.cpp
@@ -2100,7 +2100,9 @@ static void RerenderFixedPage() {
 
 void UpdateDocumentColors() {
     COLORREF text, bg;
-    GetFixedPageUiColors(text, bg);
+    GetDocumentColors(text, bg);
+    logfa("retrieved doc colors in UpdateDocumentColors: 0x%x 0x%x\n", text, bg);
+
 
     if ((text == gRenderCache.textColor) && (bg == gRenderCache.backgroundColor)) {
         return; // colors didn't change
@@ -5344,9 +5346,11 @@ static LRESULT FrameOnCommand(MainWindow* win, HWND hwnd, UINT msg, WPARAM wp, L
                 // TODO: this only rerenders canvas, not frame, even with
                 // includingNonClientArea == true.
                 // MainWindowRerender(mainWin, true);
-                RedrawWindow(win->hwndFrame, nullptr, nullptr,
+                RedrawWindow(mainWin->hwndFrame, nullptr, nullptr,
                              RDW_ERASE | RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
+                UpdateTreeCtrlColors(mainWin);
             }
+            UpdateDocumentColors();
             break;
 
         default:

--- a/src/SumatraStartup.cpp
+++ b/src/SumatraStartup.cpp
@@ -67,6 +67,7 @@
 #include "Installer.h"
 #include "ExternalViewers.h"
 #include "AppColors.h"
+#include "Theme.h"
 
 #include "utils/Log.h"
 
@@ -1167,7 +1168,8 @@ int APIENTRY WinMain(HINSTANCE hInstance, __unused HINSTANCE hPrevInstance, __un
 
     gCrashOnOpen = flags.crashOnOpen;
 
-    GetFixedPageUiColors(gRenderCache.textColor, gRenderCache.backgroundColor);
+    GetDocumentColors(gRenderCache.textColor, gRenderCache.backgroundColor);
+    logfa("retrieved doc colors in WinMain: 0x%x 0x%x\n", gRenderCache.textColor, gRenderCache.backgroundColor);
 
     gIsStartup = true;
     if (!RegisterWinClass()) {

--- a/src/Theme.cpp
+++ b/src/Theme.cpp
@@ -350,6 +350,30 @@ Theme* GetThemeByIndex(int index) {
     return g_themes[index];
 }
 
+
+void GetDocumentColors(COLORREF& text, COLORREF& bg) {
+    // Special behavior for light theme.
+    // TODO: migrate from prefs to theme.
+    if (currentThemeIndex == 0) {
+        ParsedColor* parsedCol;
+        if (gGlobalPrefs->fixedPageUI.invertColors) {
+            parsedCol = GetPrefsColor(gGlobalPrefs->fixedPageUI.textColor);
+        } else {
+            parsedCol = GetPrefsColor(gGlobalPrefs->fixedPageUI.backgroundColor);
+        }
+        bg = parsedCol->col;
+        if (gGlobalPrefs->fixedPageUI.invertColors) {
+            parsedCol = GetPrefsColor(gGlobalPrefs->fixedPageUI.backgroundColor);
+        } else {
+            parsedCol = GetPrefsColor(gGlobalPrefs->fixedPageUI.textColor);
+        }
+        text = parsedCol->col;
+    } else {
+        bg = currentTheme->document.backgroundColor;
+        text = currentTheme->document.textColor;
+    }
+}
+
 #if 0
 
 Theme* GetCurrentTheme() {

--- a/src/Theme.h
+++ b/src/Theme.h
@@ -97,3 +97,5 @@ Theme* GetCurrentTheme();
 
 int GetThemeIndex(Theme* theme);
 int GetCurrentThemeIndex();
+
+void GetDocumentColors(COLORREF& text, COLORREF& bg);


### PR DESCRIPTION
For now we maintain compatibility with gPrefs->invertColors, gPrefs->fixedPageUI.textColor etc. by always going through getDocumentColors(), and using those prefs for the light (default) theme only.

This diff should be no-op for the default theme, and starts looking promising on switching to dark theme. May need work on invalidating cached prerendered pages in non-open tabs.