### PR TITLE
Complete move from AppColors.cpp to Theme.cpp.

### DIFF
--- a/src/AppColors.cpp
+++ b/src/AppColors.cpp
@@ -25,91 +25,11 @@
 // "SumatraPDF yellow" similar to the one use for icon and installer
 #define ABOUT_BG_LOGO_COLOR RGB(0xFF, 0xF2, 0x00)
 
-// it's very light gray but not white so that there's contrast between
-// background and thumbnail, which often have white background because
-// most PDFs have white background
+
 #define ABOUT_BG_GRAY_COLOR RGB(0xF2, 0xF2, 0xF2)
 
-// for backward compatibility use a value that older versions will render as yellow
-#define ABOUT_BG_COLOR_DEFAULT (RGB(0xff, 0xf2, 0) - 0x80000000)
-
-// Background color comparison:
-// Adobe Reader X   0x565656 without any frame border
-// Foxit Reader 5   0x9C9C9C with a pronounced frame shadow
-// PDF-XChange      0xACA899 with a 1px frame and a gradient shadow
-// Google Chrome    0xCCCCCC with a symmetric gradient shadow
-// Evince           0xD7D1CB with a pronounced frame shadow
-#if defined(DRAW_PAGE_SHADOWS)
-// SumatraPDF (old) 0xCCCCCC with a pronounced frame shadow
-#define COL_WINDOW_BG RGB(0xCC, 0xCC, 0xCC)
-#define COL_PAGE_FRAME RGB(0x88, 0x88, 0x88)
-#define COL_PAGE_SHADOW RGB(0x40, 0x40, 0x40)
-#else
-// SumatraPDF       0x999999 without any frame border
-#define COL_WINDOW_BG RGB(0x99, 0x99, 0x99)
-#endif
-
-// returns the background color for start page, About window and Properties dialog
-static COLORREF GetAboutBgColor() {
-    COLORREF bgColor = ABOUT_BG_GRAY_COLOR;
-
-    ParsedColor* bgParsed = GetPrefsColor(gGlobalPrefs->mainWindowBackground);
-    if (ABOUT_BG_COLOR_DEFAULT != bgParsed->col) {
-        bgColor = bgParsed->col;
-    }
-    return bgColor;
-}
-
-// returns the background color for the "SumatraPDF" logo in start page and About window
-static COLORREF GetLogoBgColor() {
-#ifdef ABOUT_USE_LESS_COLORS
-    return ABOUT_BG_LOGO_COLOR;
-#else
-    return GetAboutBgColor();
-#endif
-}
-
-static COLORREF GetNoDocBgColor() {
-    // use the system background color if the user has non-default
-    // colors for text (not black-on-white) and also wants to use them
-
-    COLORREF sysText = GetSysColor(COLOR_WINDOWTEXT);
-    COLORREF sysWindow = GetSysColor(COLOR_WINDOW);
-    bool useSysColor = gGlobalPrefs->useSysColors && (sysText != WIN_COL_BLACK || sysWindow != WIN_COL_WHITE);
-    if (useSysColor) {
-        return GetSysColor(COLOR_BTNFACE);
-    }
-
-    return GetAboutBgColor();
-}
 
 COLORREF GetAppColor(AppColor col) {
-    if (col == AppColor::NoDocBg) {
-        // GetCurrentTheme()->document.canvasColor
-        return GetNoDocBgColor();
-    }
-
-    if (col == AppColor::AboutBg) {
-        return GetAboutBgColor();
-    }
-
-    if (col == AppColor::LogoBg) {
-        return GetLogoBgColor();
-    }
-
-    if (col == AppColor::MainWindowBg) {
-        return GetAboutBgColor();
-        // return ABOUT_BG_GRAY_COLOR;
-    }
-
-    if (col == AppColor::MainWindowText) {
-        return COL_BLACK;
-    }
-
-    if (col == AppColor::MainWindowLink) {
-        return COL_BLUE_LINK;
-    }
-
     CrashIf(true);
-    return COL_WINDOW_BG;
+    return 0;
 }

--- a/src/AppColors.h
+++ b/src/AppColors.h
@@ -4,16 +4,7 @@
 // application-wide colors
 
 enum class AppColor {
-    // background color of the main window
-    NoDocBg,
-    // background color of about window
-    AboutBg,
-    // background color of log
-    LogoBg,
 
-    MainWindowBg,
-    MainWindowText,
-    MainWindowLink,
 
 };
 

--- a/src/Canvas.cpp
+++ b/src/Canvas.cpp
@@ -739,7 +739,7 @@ static void PaintPageFrameAndShadow(HDC hdc, Rect& bounds, Rect& pageRect, bool 
 #else
 static void PaintPageFrameAndShadow(HDC hdc, Rect& bounds, Rect&, bool) {
     AutoDeletePen pen(CreatePen(PS_NULL, 0, 0));
-    auto col = GetAppColor(AppColor::MainWindowBg);
+    auto col = GetMainWindowBackgroundColor();
     AutoDeleteBrush brush(CreateSolidBrush(col));
     ScopedSelectPen restorePen(hdc, pen);
     ScopedSelectObject restoreBrush(hdc, brush);
@@ -829,7 +829,7 @@ static void DrawDocument(MainWindow* win, HDC hdc, RECT* rcArea) {
         ScopedGdiObj<HBRUSH> brush(CreateSolidBrush(WIN_COL_BLACK));
         FillRect(hdc, rcArea, brush);
     } else if (0 == nGCols) {
-        auto col = GetAppColor(AppColor::NoDocBg);
+        auto col = GetMainWindowBackgroundColor();
         ScopedGdiObj<HBRUSH> brush(CreateSolidBrush(col));
         FillRect(hdc, rcArea, brush);
     } else {
@@ -918,7 +918,7 @@ static void DrawDocument(MainWindow* win, HDC hdc, RECT* rcArea) {
         if (renderDelay != 0) {
             AutoDeleteFont fontRightTxt(CreateSimpleFont(hdc, "MS Shell Dlg", 14));
             HGDIOBJ hPrevFont = SelectObject(hdc, fontRightTxt);
-            auto col = GetAppColor(AppColor::MainWindowText);
+            auto col = currentTheme->mainWindow.textColor;
             SetTextColor(hdc, col);
             if (renderDelay != RENDER_DELAY_FAILED) {
                 if (renderDelay < REPAINT_MESSAGE_DELAY_IN_MS) {
@@ -1495,7 +1495,7 @@ static void OnPaintError(MainWindow* win) {
 
     AutoDeleteFont fontRightTxt(CreateSimpleFont(hdc, "MS Shell Dlg", 14));
     HGDIOBJ hPrevFont = SelectObject(hdc, fontRightTxt);
-    auto bgCol = GetAppColor(AppColor::NoDocBg);
+    auto bgCol = GetMainWindowBackgroundColor();
     ScopedGdiObj<HBRUSH> bgBrush(CreateSolidBrush(bgCol));
     FillRect(hdc, &ps.rcPaint, bgBrush);
     // TODO: should this be "Error opening %s"?

--- a/src/CanvasAboutUI.cpp
+++ b/src/CanvasAboutUI.cpp
@@ -24,14 +24,15 @@
 #include "Menu.h"
 #include "SumatraAbout.h"
 #include "Translations.h"
+#include "Theme.h"
 
 static void OnPaintAbout(MainWindow* win) {
     auto t = TimeGet();
     PAINTSTRUCT ps;
     HDC hdc = BeginPaint(win->hwndCanvas, &ps);
 
-    auto txtCol = GetAppColor(AppColor::MainWindowText);
-    auto bgCol = GetAppColor(AppColor::MainWindowBg);
+    auto txtCol = currentTheme->mainWindow.textColor;
+    auto bgCol = GetMainWindowBackgroundColor();
     if (HasPermission(Perm::SavePreferences | Perm::DiskAccess) && gGlobalPrefs->rememberOpenedFiles &&
         gGlobalPrefs->showStartPage) {
         DrawStartPage(win, win->buffer->GetDC(), gFileHistory, txtCol, bgCol);

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -2024,8 +2024,8 @@ void MenuOwnerDrawnDrawItem(__unused HWND hwnd, DRAWITEMSTRUCT* dis) {
     HFONT font = GetMenuFont();
     auto prevFont = SelectObject(hdc, font);
 
-    COLORREF bgCol = GetAppColor(AppColor::MainWindowBg);
-    COLORREF txtCol = GetAppColor(AppColor::MainWindowText);
+    COLORREF bgCol = GetMainWindowBackgroundColor();
+    COLORREF txtCol = currentTheme->mainWindow.textColor;
 
     bool isSelected = bit::IsMaskSet(dis->itemState, (uint)ODS_SELECTED);
     if (isSelected) {

--- a/src/SumatraAbout.cpp
+++ b/src/SumatraAbout.cpp
@@ -26,6 +26,7 @@
 #include "SumatraAbout.h"
 #include "Translations.h"
 #include "Version.h"
+#include "Theme.h"
 
 #ifndef ABOUT_USE_LESS_COLORS
 #define ABOUT_LINE_OUTER_SIZE 2
@@ -190,7 +191,7 @@ static void DrawSumatraVersion(HWND hwnd, HDC hdc, Rect rect) {
 // draw on the bottom right
 static Rect DrawHideFrequentlyReadLink(HWND hwnd, HDC hdc, const char* txt) {
     AutoDeleteFont fontLeftTxt(CreateSimpleFont(hdc, "MS Shell Dlg", 16));
-    auto col = GetAppColor(AppColor::MainWindowLink);
+    auto col = currentTheme->mainWindow.linkColor;
     AutoDeletePen penLinkLine(CreatePen(PS_SOLID, 1, col));
     ScopedSelectObject font(hdc, fontLeftTxt);
 
@@ -220,10 +221,10 @@ static Rect DrawHideFrequentlyReadLink(HWND hwnd, HDC hdc, const char* txt) {
    It transcribes the design I did in graphics software - hopeless
    to understand without seeing the design. */
 static void DrawAbout(HWND hwnd, HDC hdc, Rect rect, Vec<StaticLinkInfo*>& staticLinks) {
-    auto col = GetAppColor(AppColor::MainWindowText);
+    auto col = currentTheme->mainWindow.textColor;
     AutoDeletePen penBorder(CreatePen(PS_SOLID, ABOUT_LINE_OUTER_SIZE, col));
     AutoDeletePen penDivideLine(CreatePen(PS_SOLID, ABOUT_LINE_SEP_SIZE, col));
-    col = GetAppColor(AppColor::MainWindowLink);
+    col = currentTheme->mainWindow.linkColor;
     AutoDeletePen penLinkLine(CreatePen(PS_SOLID, ABOUT_LINE_SEP_SIZE, col));
 
     AutoDeleteFont fontLeftTxt(CreateSimpleFont(hdc, kLeftTextFont, kLeftTextFontSize));
@@ -233,7 +234,7 @@ static void DrawAbout(HWND hwnd, HDC hdc, Rect rect, Vec<StaticLinkInfo*>& stati
 
     Rect rc = ClientRect(hwnd);
     RECT rTmp = ToRECT(rc);
-    col = GetAppColor(AppColor::MainWindowBg);
+    col = GetMainWindowBackgroundColor();
     ScopedGdiObj<HBRUSH> brushAboutBg(CreateSolidBrush(col));
     FillRect(hdc, &rTmp, brushAboutBg);
 
@@ -258,7 +259,7 @@ static void DrawAbout(HWND hwnd, HDC hdc, Rect rect, Vec<StaticLinkInfo*>& stati
     DrawSumatraVersion(hwnd, hdc, titleRect);
 
     /* render attribution box */
-    col = GetAppColor(AppColor::MainWindowText);
+    col = currentTheme->mainWindow.textColor;
     SetTextColor(hdc, col);
     SetBkMode(hdc, TRANSPARENT);
 
@@ -279,9 +280,9 @@ static void DrawAbout(HWND hwnd, HDC hdc, Rect rect, Vec<StaticLinkInfo*>& stati
     for (AboutLayoutInfoEl* el = gAboutLayoutInfo; el->leftTxt; el++) {
         bool hasUrl = HasPermission(Perm::DiskAccess) && el->url;
         if (hasUrl) {
-            col = GetAppColor(AppColor::MainWindowLink);
+            col = currentTheme->mainWindow.linkColor;
         } else {
-            col = GetAppColor(AppColor::MainWindowText);
+            col = currentTheme->mainWindow.textColor;
         }
         SetTextColor(hdc, col);
         size_t txtLen = str::Len(el->rightTxt);
@@ -619,10 +620,10 @@ void DrawAboutPage(MainWindow* win, HDC hdc) {
 
 void DrawStartPage(MainWindow* win, HDC hdc, FileHistory& fileHistory, COLORREF textColor, COLORREF backgroundColor) {
     HWND hwnd = win->hwndFrame;
-    auto col = GetAppColor(AppColor::MainWindowText);
+    auto col = currentTheme->mainWindow.textColor;
     AutoDeletePen penBorder(CreatePen(PS_SOLID, DOCLIST_SEPARATOR_DY, col));
     AutoDeletePen penThumbBorder(CreatePen(PS_SOLID, DOCLIST_THUMBNAIL_BORDER_W, col));
-    col = GetAppColor(AppColor::MainWindowLink);
+    col = currentTheme->mainWindow.linkColor;
     AutoDeletePen penLinkLine(CreatePen(PS_SOLID, 1, col));
 
     AutoDeleteFont fontSumatraTxt(CreateSimpleFont(hdc, "MS Shell Dlg", 24));
@@ -634,7 +635,7 @@ void DrawStartPage(MainWindow* win, HDC hdc, FileHistory& fileHistory, COLORREF 
 
     Rect rc = ClientRect(win->hwndCanvas);
     RECT rTmp = ToRECT(rc);
-    col = GetAppColor(AppColor::MainWindowBg);
+    col = GetMainWindowBackgroundColor();
     AutoDeleteBrush brushLogoBg(CreateSolidBrush(col));
     FillRect(hdc, &rTmp, brushLogoBg);
 
@@ -652,13 +653,13 @@ void DrawStartPage(MainWindow* win, HDC hdc, FileHistory& fileHistory, COLORREF 
     /* render recent files list */
     SelectObject(hdc, penThumbBorder);
     SetBkMode(hdc, TRANSPARENT);
-    col = GetAppColor(AppColor::MainWindowText);
+    col = currentTheme->mainWindow.textColor;
     SetTextColor(hdc, col);
 
     rc.y += titleBox.dy;
     rc.dy -= titleBox.dy;
     rTmp = ToRECT(rc);
-    col = GetAppColor(AppColor::MainWindowBg);
+    col = GetMainWindowBackgroundColor();
     ScopedGdiObj<HBRUSH> brushAboutBg(CreateSolidBrush(col));
     FillRect(hdc, &rTmp, brushAboutBg);
     rc.dy -= DOCLIST_BOTTOM_BOX_DY;
@@ -767,7 +768,7 @@ void DrawStartPage(MainWindow* win, HDC hdc, FileHistory& fileHistory, COLORREF 
         DOCLIST_MARGIN_TOP + height * kThumbnailDy + (height - 1) * DOCLIST_MARGIN_BETWEEN_Y + DOCLIST_MARGIN_BOTTOM;
     rc.dy = DOCLIST_BOTTOM_BOX_DY;
 
-    col = GetAppColor(AppColor::MainWindowLink);
+    col = currentTheme->mainWindow.linkColor;
     SetTextColor(hdc, col);
     SelectObject(hdc, penLinkLine);
 

--- a/src/SumatraProperties.cpp
+++ b/src/SumatraProperties.cpp
@@ -27,6 +27,7 @@
 #include "Translations.h"
 #include "SumatraConfig.h"
 #include "Print.h"
+#include "Theme.h"
 
 void ShowProperties(HWND parent, DocController* ctrl, bool extended);
 
@@ -600,11 +601,11 @@ static void DrawProperties(HWND hwnd, HDC hdc) {
 
     Rect rcClient = ClientRect(hwnd);
     RECT rTmp = ToRECT(rcClient);
-    auto col = GetAppColor(AppColor::MainWindowBg);
+    auto col = GetMainWindowBackgroundColor();
     ScopedGdiObj<HBRUSH> brushAboutBg(CreateSolidBrush(col));
     FillRect(hdc, &rTmp, brushAboutBg);
 
-    col = GetAppColor(AppColor::MainWindowText);
+    col = currentTheme->mainWindow.textColor;
     SetTextColor(hdc, col);
 
     /* render text on the left*/

--- a/src/Theme.cpp
+++ b/src/Theme.cpp
@@ -31,6 +31,7 @@ Note: Colors are in format 0xBBGGRR, recommended to use RgbToCOLORREF
 #define COL_WHITEISH 0xEBEBF9
 #define COL_DARK_GRAY 0x424242
 
+
 // Theme definition helper functions
 static COLORREF RgbToCOLORREF(COLORREF rgb) {
     return ((rgb & 0x0000FF) << 16) | (rgb & 0x00FF00) | ((rgb & 0xFF0000) >> 16);
@@ -44,6 +45,17 @@ Theme g_themeLight = {
     // Main window theme
     {
         // Main Background Color
+        // Background color comparison:
+        // Adobe Reader X   0x565656 without any frame border
+        // Foxit Reader 5   0x9C9C9C with a pronounced frame shadow
+        // PDF-XChange      0xACA899 with a 1px frame and a gradient shadow
+        // Google Chrome    0xCCCCCC with a symmetric gradient shadow
+        // Evince           0xD7D1CB with a pronounced frame shadow
+        // SumatraPDF (old) 0xCCCCCC with a pronounced frame shadow
+
+        // it's very light gray but not white so that there's contrast between
+        // background and thumbnail, which often have white background because
+        // most PDFs have white background.
         RgbToCOLORREF(0xF2F2F2),
         // Main Text Color
         COL_BLACK,
@@ -371,6 +383,23 @@ void GetDocumentColors(COLORREF& text, COLORREF& bg) {
         bg = currentTheme->document.backgroundColor;
         text = currentTheme->document.textColor;
     }
+}
+
+COLORREF GetMainWindowBackgroundColor() {
+    COLORREF bgColor = currentTheme->mainWindow.backgroundColor;
+    // Special behavior for light theme.
+    // TODO: migrate from prefs to theme.
+    if (currentThemeIndex == 0) {
+
+// for backward compatibility use a value that older versions will render as yellow
+#define MAIN_WINDOW_BG_COLOR_DEFAULT (RGB(0xff, 0xf2, 0) - 0x80000000)
+
+        ParsedColor* bgParsed = GetPrefsColor(gGlobalPrefs->mainWindowBackground);
+        if (MAIN_WINDOW_BG_COLOR_DEFAULT != bgParsed->col) {
+            bgColor = bgParsed->col;
+        }
+    }
+    return bgColor;
 }
 
 #if 0

--- a/src/Theme.h
+++ b/src/Theme.h
@@ -98,4 +98,8 @@ Theme* GetCurrentTheme();
 int GetThemeIndex(Theme* theme);
 int GetCurrentThemeIndex();
 
+// These functions take into account both gPrefs and the theme.
+// Access to these colors must go through them until everything is
+// configured through themes.
 void GetDocumentColors(COLORREF& text, COLORREF& bg);
+COLORREF GetMainWindowBackgroundColor();


### PR DESCRIPTION
- main window colors are now thematized, including canvas around doc
- AppColors.{h,cpp} not deleted, in a separate later commit. No callers remain
- these AppColor values are collapsed into "main window background": NoDocBg, LogoBg, MainWindowBg, AboutBg. They were in practice almost always the same
- the use of gSysColors is obsoleted (were consuled in NoDocBg). The use of #ABOUT_USE_LESS_COLORS is dropped.
- on the other hand, mainWindowBackground in gprefs is consulted when in the light theme, for backward compatibility.