### PR TITLE
Thematize menus, both main and popup.

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1899,7 +1899,7 @@ void FreeMenuOwnerDrawInfoData(HMENU hmenu) {
     };
 }
 void MarkMenuOwnerDraw(HMENU hmenu) {
-    if (!gOwnerDrawMenu) {
+    if (!currentTheme->colorizeControls) {
         return;
     }
     WCHAR buf[1024];

--- a/src/SumatraConfig.cpp
+++ b/src/SumatraConfig.cpp
@@ -46,13 +46,6 @@ const char* gitCommidId = QM(GIT_COMMIT_ID);
 const char* gitCommidId = nullptr;
 #endif
 
-// experimental, unfinished theme support for menus by making them owner-drawn
-#if defined(EXP_MENU_OWNER_DRAW)
-bool gOwnerDrawMenu = true;
-#else
-bool gOwnerDrawMenu = false;
-#endif
-
 #ifdef DISABLE_DOCUMENT_RESTRICTIONS
 bool gDisableDocumentRestrictions = true;
 #else

--- a/src/SumatraConfig.h
+++ b/src/SumatraConfig.h
@@ -9,7 +9,6 @@ extern bool gIsDebugBuild;
 extern bool gIsAsanBuild;
 extern bool gIsPreReleaseBuild;
 extern bool gIsStoreBuild;
-extern bool gOwnerDrawMenu;
 extern bool gDisableDocumentRestrictions;
 extern const char* builtOn;
 extern const char* currentVersion; // e.g. "3.2.1138"

--- a/src/SumatraPDF.cpp
+++ b/src/SumatraPDF.cpp
@@ -5366,6 +5366,7 @@ static LRESULT FrameOnCommand(MainWindow* win, HWND hwnd, UINT msg, WPARAM wp, L
                 RedrawWindow(mainWin->hwndFrame, nullptr, nullptr,
                              RDW_ERASE | RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
                 UpdateTreeCtrlColors(mainWin);
+                RebuildMenuBarForWindow(mainWin);
             }
             UpdateDocumentColors();
             break;
@@ -5442,14 +5443,14 @@ LRESULT CALLBACK WndProcSumatraFrame(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) 
             return FrameOnCommand(win, hwnd, msg, wp, lp);
 
         case WM_MEASUREITEM:
-            if (gOwnerDrawMenu) {
+            if (currentTheme->colorizeControls) {
                 MenuOwnerDrawnMesureItem(hwnd, (MEASUREITEMSTRUCT*)lp);
                 return TRUE;
             }
             break;
 
         case WM_DRAWITEM:
-            if (gOwnerDrawMenu) {
+            if (currentTheme->colorizeControls) {
                 MenuOwnerDrawnDrawItem(hwnd, (DRAWITEMSTRUCT*)lp);
                 return TRUE;
             }

--- a/src/Theme.cpp
+++ b/src/Theme.cpp
@@ -141,7 +141,9 @@ Theme g_themeLight = {
         RgbToCOLORREF(0x8d0801),
         // Progress bar color
         g_themeLight.mainWindow.linkColor
-    }
+    },
+    // Colorize standard controls
+    false
 };
 
 Theme g_themeDark = {
@@ -225,7 +227,9 @@ Theme g_themeDark = {
         g_themeDark.mainWindow.textColor,
         // Progress bar color
         g_themeDark.mainWindow.linkColor
-    }
+    },
+    // Colorize standard controls
+    true
 };
 
 Theme g_themeDarker = {
@@ -318,7 +322,9 @@ Theme g_themeDarker = {
         g_themeDarker.mainWindow.textColor,
         // Progress bar color
         g_themeDarker.mainWindow.linkColor
-    }
+    },
+    // Colorize standard controls
+    true
 };
 // clang-format on
 

--- a/src/Theme.h
+++ b/src/Theme.h
@@ -85,6 +85,8 @@ struct Theme {
     TabTheme tab;
     // Style of notifications
     NotificationStyle notifications;
+    // Whether or not we colorize standard Windows controls and window areas
+    bool colorizeControls;
 };
 
 extern Theme* currentTheme;


### PR DESCRIPTION
A theme now indicates whether its controls should be standard Windows colors, or we tinker as much as possible to adapt them to the theme. The default light theme leaves controls alone. The dark theme should try to adapt menus, edit boxes, static controls, toolbars, etc.