### PR TITLE
Thematize toolbar

### DIFF
--- a/src/Caption.cpp
+++ b/src/Caption.cpp
@@ -165,7 +165,7 @@ void CaptionInfo::UpdateColors(bool activeWindow) {
                                                                   : GetSysColor(COLOR_INACTIVECAPTIONTEXT);
     }
     if (gGlobalPrefs->useTabs) {
-        COLORREF col = currentTheme->mainWindow.captionBackgroundColor;
+        COLORREF col = currentTheme->mainWindow.controlBackgroundColor;
         dwm::SetCaptionColor(::GetParent(hwnd), col);
     }
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -127,6 +127,7 @@ MainWindow::~MainWindow() {
 
     DeleteObject(brMovePattern);
     DeleteObject(bmpMovePattern);
+    DeleteObject(brControlBgColor);
 
     // release our copy of UIA provider
     // the UI automation still might have a copy somewhere

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -204,6 +204,7 @@ struct MainWindow {
     Point annotationBeingMovedOffset;
     HBITMAP bmpMovePattern = nullptr;
     HBRUSH brMovePattern = nullptr;
+    HBRUSH brControlBgColor = nullptr;
 
     DocControllerCallback* cbHandler = nullptr;
 

--- a/src/SumatraPDF.cpp
+++ b/src/SumatraPDF.cpp
@@ -1452,6 +1452,7 @@ static MainWindow* CreateMainWindow() {
     if (!win->isMenuHidden) {
         SetMenu(win->hwndFrame, win->menu);
     }
+    win->brControlBgColor = CreateSolidBrush(currentTheme->mainWindow.controlBackgroundColor);
 
     ShowWindow(win->hwndCanvas, SW_SHOW);
     UpdateWindow(win->hwndCanvas);
@@ -1536,6 +1537,15 @@ void DeleteMainWindow(MainWindow* win) {
     }
 
     delete win;
+}
+
+static void UpdateThemeForWindow(MainWindow* win) {
+    DeleteObject(win->brControlBgColor);
+    win->brControlBgColor = CreateSolidBrush(currentTheme->mainWindow.controlBackgroundColor);
+
+    UpdateTreeCtrlColors(win);
+    RebuildMenuBarForWindow(win);
+    RedrawWindow(win->hwndFrame, nullptr, nullptr, RDW_ERASE | RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
 }
 
 static void RenameFileInHistory(const char* oldPath, const char* newPath) {
@@ -5370,10 +5380,8 @@ static LRESULT FrameOnCommand(MainWindow* win, HWND hwnd, UINT msg, WPARAM wp, L
                 // TODO: this only rerenders canvas, not frame, even with
                 // includingNonClientArea == true.
                 // MainWindowRerender(mainWin, true);
-                RedrawWindow(mainWin->hwndFrame, nullptr, nullptr,
-                             RDW_ERASE | RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN);
-                UpdateTreeCtrlColors(mainWin);
-                RebuildMenuBarForWindow(mainWin);
+                UpdateThemeForWindow(mainWin);
+                
             }
             UpdateDocumentColors();
             break;

--- a/src/Theme.cpp
+++ b/src/Theme.cpp
@@ -56,12 +56,12 @@ Theme g_themeLight = {
         // background and thumbnail, which often have white background because
         // most PDFs have white background.
         RgbToCOLORREF(0xF2F2F2),
+        // Control background Color
+        COL_WHITE,
         // Main Text Color
         COL_BLACK,
         // Main Link Color
-        RgbToCOLORREF(0x0020A0),
-        // Caption background Color
-        RgbToCOLORREF(0xEEEEEE)
+        RgbToCOLORREF(0x0020A0)
     },
     // Document style
     {
@@ -153,12 +153,13 @@ Theme g_themeDark = {
     {
         // Main Background Color
         RgbToCOLORREF(0x263238),
+         // Control background Color
+        RgbToCOLORREF(0x263238),
         // Main Text Color
         COL_WHITE,
         // Main Link Color
-        RgbToCOLORREF(0x80CBAD),
-        // Caption background Color
-        RgbToCOLORREF(0x263238)
+        RgbToCOLORREF(0x80CBAD)
+       
     },
     // Document style
     {
@@ -239,12 +240,12 @@ Theme g_themeDarker = {
     {
         // Main Background Color
         RgbToCOLORREF(0x2D2D30),
+         // Control background Color
+        RgbToCOLORREF(0x2D2D30),
         // Main Text Color
         COL_WHITE,
         // Main Link Color
-        RgbToCOLORREF(0x3081D4),
-        // Caption background Color
-        RgbToCOLORREF(0x2D2D30)
+        RgbToCOLORREF(0x3081D4)
     },
     // Document style
     {

--- a/src/Theme.h
+++ b/src/Theme.h
@@ -9,12 +9,12 @@ License: GPLv3 */
 struct MainWindowStyle {
     // Background color of recently added, about, and properties menus
     COLORREF backgroundColor;
+    // Background color of controls, menus, non-client areas, etc.
+    COLORREF controlBackgroundColor;
     // Text color of recently added, about, and properties menus
     COLORREF textColor;
     // Link color on recently added, about, and properties menus
     COLORREF linkColor;
-    // Background color of the caption area when we use it for tabs
-    COLORREF captionBackgroundColor;
 };
 
 struct DocumentStyle {

--- a/src/wingui/WinGui.cpp
+++ b/src/wingui/WinGui.cpp
@@ -3403,7 +3403,7 @@ void TabsCtrl::Paint(HDC hdc, RECT& rc) {
     gfx.SetTextRenderingHint(TextRenderingHintClearTypeGridFit);
     gfx.SetPageUnit(UnitPixel);
 
-    SolidBrush br(GdipCol(currentTheme->mainWindow.captionBackgroundColor));
+    SolidBrush br(GdipCol(currentTheme->mainWindow.controlBackgroundColor));
 
     Font f(hdc, GetDefaultGuiFont());
 


### PR DESCRIPTION
Renamed captionBackgroundColor to controlBackgroundColor, the color to be used on the background of all controls, captions, menus etc. Pure white in the default theme (but also code should preferably not even use it in the default theme, honoring theme->colorizeControls == false).

No-op on the default theme. Dark/darker themes look OKish... they need some tweaking on the bitmaps which look a bit wonky. I don't fully understand why the bitmaps look much better when switched to the About window, will look into it separately.