### PR TITLE
When possible use pdf_has_unsaved_changes(), which resets on save

### DIFF
--- a/src/EngineMupdf.cpp
+++ b/src/EngineMupdf.cpp
@@ -3433,9 +3433,11 @@ bool EngineMupdfHasUnsavedAnnotations(EngineBase* engine) {
         return false;
     }
     // pdf_has_unsaved_changes() also returns true if the file was auto-repaired
-    // at loading time, which is not something we want
-    // int res = pdf_has_unsaved_changes(epdf->ctx, epdf->pdfdoc);
-    // return res != 0;
+    // at loading time, which is not something we want, so only rely on it
+    // when we know it wasn't repaired.
+    if (!pdf_was_repaired(epdf->ctx, epdf->pdfdoc)) {
+        return pdf_has_unsaved_changes(epdf->ctx, epdf->pdfdoc);
+    }   
     return epdf->modifiedAnnotations;
 }
 

--- a/src/libmupdf.def
+++ b/src/libmupdf.def
@@ -30,6 +30,7 @@ EXPORTS
 	fz_transform_page
 	fz_load_chapter_page
 	fz_run_page_contents
+	pdf_was_repaired
 	pdf_has_unsaved_changes
 	pdf_can_be_saved_incrementally
 	pdf_annot_page


### PR DESCRIPTION
If the file was repaired on load (relatively rare), switch to inferior tracking of our own. Fixes #3417.