### PR TITLE
fix home tab's initial state is highlighted

### DIFF
--- a/src/Favorites.cpp
+++ b/src/Favorites.cpp
@@ -808,7 +808,7 @@ static void FavTreeContextMenu(ContextMenuEvent* ev) {
     HMENU popup = BuildMenuFromMenuDef(menuDefContextFav, CreatePopupMenu(), nullptr);
     MarkMenuOwnerDraw(popup);
     uint flags = TPM_RETURNCMD | TPM_RIGHTBUTTON;
-    int cmd = TrackPopupMenu(popup, flags, pt.x, pt.y, 0, hwnd, nullptr);
+    int cmd = TrackPopupMenu(popup, flags, pt.x, pt.y, 0, win->hwndFrame, nullptr);
     FreeMenuOwnerDrawInfoData(popup);
     DestroyMenu(popup);
 

--- a/src/wingui/WinGui.h
+++ b/src/wingui/WinGui.h
@@ -731,7 +731,7 @@ struct TabsCtrl : Wnd {
     int tabHighlighted = -1;
     int tabHighlightedClose = -1;
     int tabBeingClosed = -1;
-    Point lastMousePos;
+    Point lastMousePos{-1,-1};
     // where we grabbed the tab with a leftclick, in tab coordinates
     Point grabLocation;
 


### PR DESCRIPTION
UseTabs = true 
NoHomeTab = false
open a pdf file -> close -> open, home tab state is always highlighted