### PR TITLE
Add "QuietUninstallString" to registry

### DIFF
--- a/src/RegistryInstaller.cpp
+++ b/src/RegistryInstaller.cpp
@@ -86,6 +86,7 @@ bool WriteUninstallerRegistryInfo(HKEY hkey) {
     ok &= LoggedWriteRegStr(hkey, regPathUninst, "Publisher", kPublisherStr);
     // command line for uninstaller
     ok &= LoggedWriteRegStr(hkey, regPathUninst, "UninstallString", uninstallCmdLine);
+    ok &= LoggedWriteRegStr(hkey, regPathUninst, "QuietUninstallString", uninstallCmdLine + " -silent");
     ok &= LoggedWriteRegStr(hkey, regPathUninst, "URLInfoAbout", "https://www.sumatrapdfreader.org/");
     ok &= LoggedWriteRegStr(hkey, regPathUninst, "URLUpdateInfo",
                             "https://www.sumatrapdfreader.org/docs/Version-history.html");


### PR DESCRIPTION
**CHANGE:**

This PR adds the registry key `QuietUninstallString`, providing the command line required to silently uninstall the application.

**MOTIVATION:**

1) Although `QuietUninstallString` isn't mandatory, it is customary for uninstallers that offer a silent option.

2) The [WinGet](https://github.com/microsoft/winget-cli) package manager attempts to install/uninstall applications silently by default. The [SumatraPDF.SumatraPDF](https://github.com/microsoft/winget-pkgs/tree/master/manifests/s/SumatraPDF/SumatraPDF/3.4.6) package installs silently, but runs the uninstaller interactively. This occurs because WinGet falls back to `UninstallString` if `QuietUninstallString` is missing.