### PR TITLE
Dark Mode with toolbar icon

### DIFF
--- a/src/Commands.h
+++ b/src/Commands.h
@@ -172,6 +172,7 @@ Cmd* enum (e.g. CmdOpen) and a human-readable name (not used yet).
     V(CmdNextTab, "Next Tab")                                             \
     V(CmdPrevTab, "Previous Tab")                                         \
     V(CmdCycleTheme, "Switch to next theme")                              \
+    V(CmdDarkMode, "Switch to dark mode")                              \
     V(CmdNone, "Do nothing")
 
 // order of CreateAnnot* must be the same as enum AnnotationType

--- a/src/SumatraPDF.cpp
+++ b/src/SumatraPDF.cpp
@@ -4755,6 +4755,12 @@ static LRESULT FrameOnCommand(MainWindow* win, HWND hwnd, UINT msg, WPARAM wp, L
             OpenFile(win);
             break;
 
+        case CmdDarkMode:
+            gRenderCache.textColor = ((0xffffff & 0x0000FF) << 16) | (0xffffff & 0x00FF00) | ((0xffffff & 0xFF0000) >> 16);
+            gRenderCache.backgroundColor = ((0x000000 & 0x0000FF) << 16) | (0x000000 & 0x00FF00) | ((0x000000 & 0xFF0000) >> 16);
+            RerenderEverything();
+            break;
+
         case CmdOpenFolder:
             OpenFolder(win);
             break;

--- a/src/SvgIcons.cpp
+++ b/src/SvgIcons.cpp
@@ -141,6 +141,12 @@ static const char* gIconRotateRight =
   <circle cx="11" cy="19.94" r="0.15"/>
 </svg>)";
 
+static const char* gIconDarkMode =
+    R"(<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-moon" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+   <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+   <path d="M12 3c.132 0 .263 0 .393 0a7.5 7.5 0 0 0 7.92 12.446a9 9 0 1 1 -8.313 -12.454z"></path>
+</svg>)";
+
 // must match order in enum class TbIcon
 // clang-format off
 static const char* gAllIcons[] = {
@@ -159,6 +165,7 @@ static const char* gAllIcons[] = {
     gIconSave,
     gIconRotateLeft,
     gIconRotateRight,
+    gIconDarkMode,
 };
 // clang-format on
 

--- a/src/SvgIcons.h
+++ b/src/SvgIcons.h
@@ -21,4 +21,5 @@ enum class TbIcon {
     Save,
     RotateLeft,
     RotateRight,
+    DarkMode
 };

--- a/src/Toolbar.cpp
+++ b/src/Toolbar.cpp
@@ -82,6 +82,7 @@ static ToolbarButtonInfo gToolbarButtons[] = {
     {TbIcon::SearchNext, CmdFindNext, _TRN("Find Next")},
     {TbIcon::MatchCase, CmdFindMatch, _TRN("Match Case")},
     {TbIcon::None, CmdInfoText, nullptr}, // info text
+    {TbIcon::DarkMode,CmdDarkMode,_TRN("dark mode")},
 };
 
 constexpr int kButtonsCount = dimof(gToolbarButtons);
@@ -143,6 +144,9 @@ static bool IsToolbarButtonEnabled(MainWindow* win, int buttonNo) {
         case CmdPrint:
             isAllowed = HasPermission(Perm::PrinterAccess);
             break;
+        case CmdDarkMode:
+            printf("dark mode activated\n");
+        break;
     }
     if (!isAllowed) {
         return false;


### PR DESCRIPTION
On the toolbar I have added the darkmode icon (half moon). Which changes the text color to #ffffff and background-color to #000000. After changing the color, It calls RerenderEverything() which re-renders everything and changes color in real-time.