### PR TITLE
Deletion of an annotation should not adjust PDF view

### DIFF
--- a/src/EditAnnotations.cpp
+++ b/src/EditAnnotations.cpp
@@ -844,6 +844,7 @@ void DeleteAnnotationAndUpdateUI(WindowTab* tab, EditAnnotationsWindow* ew, Anno
     DeleteAnnotation(annot);
     if (ew != nullptr) {
         // can be null if called from Menu.cpp and annotations window is not visible
+        ew->skipGoToPage = true;
         RebuildAnnotations(ew);
         UpdateUIForSelectedAnnotation(ew, 0);
         ew->listBox->SetCurrentSelection(0);


### PR DESCRIPTION
This is a fix for https://github.com/sumatrapdfreader/sumatrapdf/issues/2816 -- it was surprisingly easy!