### PR TITLE
"Select Annotation in Editor" didn't work when triggered via a shortcut key.

### DIFF
--- a/src/Accelerators.cpp
+++ b/src/Accelerators.cpp
@@ -201,6 +201,9 @@ ACCEL gBuiltInAccelerators[] = {
     {0, 'u', CmdCreateAnnotUnderline},
     {0, 'U', CmdCreateAnnotUnderline},
 
+    {0, 'e', CmdEditAnnotations},
+    {0, 'E', CmdEditAnnotations},
+
     {0, 'i', CmdInvertColors},
     {0, 'I', CmdTogglePageInfo},
 

--- a/src/Canvas.cpp
+++ b/src/Canvas.cpp
@@ -612,6 +612,7 @@ static void OnMouseLeftButtonDblClk(MainWindow* win, int x, int y, WPARAM key) {
         Annotation* annot = dm->GetAnnotationAtPos(mousePos, nullptr);
         if (annot) {
             StartEditAnnotations(win->CurrentTab(), annot);
+            RepaintAsync(win, 0);
             return;
         }
     }

--- a/src/EditAnnotations.cpp
+++ b/src/EditAnnotations.cpp
@@ -1375,7 +1375,9 @@ void SelectAnnotationInEditWindow(EditAnnotationsWindow* ew, Annotation* annot) 
 
 void StartEditAnnotations(WindowTab* tab, Annotation* annot) {
     Vec<Annotation*> annots;
-    annots.Append(annot);
+    if (annot) {
+        annots.Append(annot); 
+    }
     StartEditAnnotations(tab, annots);
 }
 

--- a/src/SumatraPDF.cpp
+++ b/src/SumatraPDF.cpp
@@ -5255,10 +5255,10 @@ static LRESULT FrameOnCommand(MainWindow* win, HWND hwnd, UINT msg, WPARAM wp, L
             break;
 
         case CmdSelectAnnotation:
-            annotationUnderCursor = GetAnnotionUnderCursor(tab);
             [[fallthrough]];
 
         case CmdEditAnnotations:
+            annotationUnderCursor = GetAnnotionUnderCursor(tab);
             StartEditAnnotations(tab, nullptr);
             if (annotationUnderCursor) {
                 SelectAnnotationInEditWindow(tab->editAnnotsWindow, annotationUnderCursor);


### PR DESCRIPTION
Here are a few small fixes for https://github.com/sumatrapdfreader/sumatrapdf/pull/3663

- I discovered an existing bug: *"Select Annotation in Editor"* didn't work when triggered via a shortcut (accelerator) key.
- I added a default accelerator key, `E`, for *"Select Annotation in Editor"*
- ctrl-double-click on an annotation didn't highlight the annotation
- I removed some logic that was adding `null` annotations to the annotation list, even though it didn't seem to cause a problem
