### PR TITLE
Improvements to save

### DIFF
--- a/src/EditAnnotations.cpp
+++ b/src/EditAnnotations.cpp
@@ -352,29 +352,11 @@ static void ButtonSaveToNewFileHandler(EditAnnotationsWindow* ew) {
 
 static void ButtonSaveToCurrentPDFHandler(EditAnnotationsWindow* ew) {
     WindowTab* tab = ew->tab;
-    EngineMupdf* engine = GetEngineMupdf(ew);
-    const char* path = engine->FilePath();
-    bool ok = EngineMupdfSaveUpdated(engine, {}, [&tab, &path](const char* mupdfErr) {
-        str::Str msg;
-        // TODO: duplicated message
-        msg.AppendFmt(_TRA("Saving of '%s' failed with: '%s'"), path, mupdfErr);
-        NotificationCreateArgs args;
-        args.hwndParent = tab->win->hwndCanvas;
-        args.msg = msg.Get();
-        args.warning = true;
-        args.timeoutMs = 0;
-        ShowNotification(args);
-    });
+
+    bool ok = SaveDocument(tab, {}, true);
     if (!ok) {
         return;
     }
-    str::Str msg;
-    msg.AppendFmt(_TRA("Saved annotations to '%s'"), path);
-    NotificationCreateArgs args;
-    args.hwndParent = tab->win->hwndCanvas;
-    args.timeoutMs = 5000;
-    args.msg = msg.Get();
-    ShowNotification(args);
 
     // TODO: hacky: set tab->editAnnotsWindow to nullptr to
     // disable a check in ReloadDocuments. Could pass additional argument

--- a/src/SumatraPDF.cpp
+++ b/src/SumatraPDF.cpp
@@ -2474,6 +2474,7 @@ static bool MaybeSaveAnnotations(WindowTab* tab) {
             break;
         case SaveChoice::SaveExisting: {
             SaveDocument(tab, {}, false);
+            ReloadDocument(tab->win, false);
         } break;
         case SaveChoice::Cancel:
             tab->askedToSaveAnnotations = false;
@@ -4445,7 +4446,7 @@ static void SaveAnnotationsAndCloseEditAnnotationsWindow(WindowTab* tab) {
     if (!SaveDocument(tab, {}, true)) {
         return;
     }
-
+    ReloadDocument(tab->win, false);
     CloseAndDeleteEditAnnotationsWindow(tab->editAnnotsWindow);
     tab->editAnnotsWindow = nullptr;
 }

--- a/src/SumatraPDF.h
+++ b/src/SumatraPDF.h
@@ -118,6 +118,7 @@ void SetCurrentLanguageAndRefreshUI(const char* langCode);
 void UpdateDocumentColors();
 void UpdateFixedPageScrollbarsVisibility();
 void UpdateTabFileDisplayStateForTab(WindowTab* tab);
+bool SaveDocument(WindowTab* tab, const char* path, const bool successNotification);
 void ReloadDocument(MainWindow* win, bool autoRefresh);
 void ToggleFullScreen(MainWindow* win, bool presentation = false);
 void RelayoutWindow(MainWindow* win);


### PR DESCRIPTION
This is the first step towards fixing https://github.com/sumatrapdfreader/sumatrapdf/issues/3551. All I have done is refactored out a lot of duplicated code that helps with readability, and gives one "save" method that can be updated with the reloading etc code.

I don't think I'm the person to add "the reloading etc code" -- there are an awful lot of "if, buts, and maybes" in these methods.

**EDIT:** I added a cheap fix. I don't really like it, ~but it seems to work~. I would prefer all reloading to exist within the new `SaveDocument` method. 
