### PR TITLE
Annotation editor switches tabs

### DIFF
--- a/src/EditAnnotations.cpp
+++ b/src/EditAnnotations.cpp
@@ -1384,8 +1384,11 @@ void StartEditAnnotations(WindowTab* tab, Vec<Annotation*>& annots) {
     args.icon = LoadIconW(h, iconName);
     // mainWindow->isDialog = true;
     args.bgColor = MkGray(0xee);
-    args.title = _TRA("Annotations");
 
+    std::string result = _TRA("Annotations") + std::string(": ") +
+                         tab->GetTabTitle();
+    args.title = result.c_str();
+ 
     // PositionCloseTo(w, args->hwndRelatedTo);
     // SIZE winSize = {w->initialSize.dx, w->initialSize.Height};
     // LimitWindowSizeToScreen(args->hwndRelatedTo, winSize);

--- a/src/EditAnnotations.cpp
+++ b/src/EditAnnotations.cpp
@@ -1384,10 +1384,7 @@ void StartEditAnnotations(WindowTab* tab, Vec<Annotation*>& annots) {
     args.icon = LoadIconW(h, iconName);
     // mainWindow->isDialog = true;
     args.bgColor = MkGray(0xee);
-
-    std::string result = _TRA("Annotations") + std::string(": ") +
-                         tab->GetTabTitle();
-    args.title = result.c_str();
+    args.title = str::JoinTemp(_TRA("Annotations"), ": ", tab->GetTabTitle());
  
     // PositionCloseTo(w, args->hwndRelatedTo);
     // SIZE winSize = {w->initialSize.dx, w->initialSize.Height};

--- a/src/EditAnnotations.cpp
+++ b/src/EditAnnotations.cpp
@@ -114,6 +114,7 @@ const char* GetKnownColorName(PdfColor c) {
 struct EditAnnotationsWindow : Wnd {
     void OnSize(UINT msg, UINT type, SIZE size) override;
     void OnClose() override;
+    void OnFocus() override;
 
     WindowTab* tab = nullptr;
     LayoutBase* mainLayout = nullptr;
@@ -337,6 +338,10 @@ static void RebuildAnnotations(EditAnnotationsWindow* ew) {
 void EditAnnotationsWindow::OnClose() {
     tab->editAnnotsWindow = nullptr;
     delete this; // sketchy
+}
+
+void EditAnnotationsWindow::OnFocus() {
+    SelectTabInWindow(tab);
 }
 
 extern bool SaveAnnotationsToMaybeNewPdfFile(WindowTab* tab);

--- a/src/wingui/WinGui.cpp
+++ b/src/wingui/WinGui.cpp
@@ -387,6 +387,9 @@ int Wnd::OnCreate(CREATESTRUCT*) {
 void Wnd::OnDestroy() {
 }
 
+void Wnd::OnFocus() {
+}
+
 // Called when the background of the window's client area needs to be erased.
 // Override this function in your derived class to perform drawing tasks.
 // Return Value: Return FALSE to also permit default erasure of the background
@@ -743,6 +746,10 @@ LRESULT Wnd::WndProcDefault(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) {
             break; // Note: Some controls require default processing.
         }
 
+        case WM_SETFOCUS: {
+            OnFocus();
+            break;
+        }
         case WM_NOTIFY: {
             // Do notification reflection if message came from a child window.
             // Restricting OnNotifyReflect to child windows avoids double handling.

--- a/src/wingui/WinGui.h
+++ b/src/wingui/WinGui.h
@@ -94,6 +94,8 @@ struct Wnd : public ILayout {
     virtual LRESULT OnMessageReflect(UINT msg, WPARAM wparam, LPARAM lparam);
 
     virtual void OnAttach();
+    virtual void OnFocus();
+
     virtual bool OnCommand(WPARAM wparam, LPARAM lparam);
     virtual void OnClose();
     virtual int OnCreate(CREATESTRUCT*);


### PR DESCRIPTION
Here are some minor quality-of-life improvements to the Annotation Editor I discovered while trying to work with multiple annotation editors being open at the same time.

1. When I click on an Annotation Editor, I now see the PDF content that the Annotations are related to. Previously I had to manually click on the tab, which got pretty tedious.
2. The Annotation Editor Title now includes the name of the associated PDF, which makes it easier to tell which window is which