### PR TITLE
ESC in 'Find' dialog returns start page

### DIFF
--- a/src/SearchAndDDE.cpp
+++ b/src/SearchAndDDE.cpp
@@ -67,6 +67,7 @@ bool NeedsFindUI(MainWindow* win) {
     }
     return true;
 }
+int initialPage = 0;
 
 void FindFirst(MainWindow* win) {
     if (win->AsChm()) {
@@ -321,6 +322,13 @@ static void FindEndTask(MainWindow* win, FindThreadData* ftd, TextSel* textSel, 
     delete ftd;
 }
 
+void ReturnToInitialFindPage(MainWindow* win) {
+    if (initialPage) {
+        DisplayModel* dm = win->AsFixed();
+        dm->GoToPage(initialPage, false);
+    }
+}
+
 static DWORD WINAPI FindThread(LPVOID data) {
     FindThreadData* ftd = (FindThreadData*)data;
     CrashIf(!(ftd && ftd->win && ftd->win->ctrl && ftd->win->ctrl->AsFixed()));
@@ -381,6 +389,15 @@ void AbortFinding(MainWindow* win, bool hideMessage) {
 void FindTextOnThread(MainWindow* win, TextSearchDirection direction, const char* text, bool wasModified,
                       bool showProgress) {
     AbortFinding(win, false);
+
+    static char prevSearchText[256] = "";
+    if (str::IsEmpty(prevSearchText) || !str::StartsWith(text, prevSearchText)) {
+        DisplayModel* dm = win->AsFixed();
+        initialPage = dm->CurrentPageNo();
+    }
+
+    strncpy(prevSearchText, text, 256);
+
     if (str::IsEmpty(text)) {
         return;
     }

--- a/src/SearchAndDDE.h
+++ b/src/SearchAndDDE.h
@@ -26,6 +26,7 @@ void FindFirst(MainWindow* win);
 void FindToggleMatchCase(MainWindow* win);
 void FindSelection(MainWindow* win, TextSearchDirection direction);
 void AbortFinding(MainWindow* win, bool hideMessage);
+void ReturnToInitialFindPage(MainWindow* win);
 void FindTextOnThread(MainWindow* win, TextSearchDirection direction, bool showProgress);
 void FindTextOnThread(MainWindow* win, TextSearchDirection direction, const char* text, bool wasModified,
                       bool showProgress);

--- a/src/Toolbar.cpp
+++ b/src/Toolbar.cpp
@@ -360,9 +360,8 @@ static LRESULT CALLBACK WndProcEditSearch(HWND hwnd, UINT msg, WPARAM wp, LPARAM
             case VK_ESCAPE:
                 if (win->findThread) {
                     AbortFinding(win, true);
-                } else {
-                    SetFocus(win->hwndFrame);
                 }
+                ReturnToInitialFindPage(win);
                 return 1;
 
             case VK_RETURN: {


### PR DESCRIPTION
I've spent most of today working through a rather large pdf, adding lots of comments, and doing lots of searches, so I've found an irritation, which I have scratched :-)

This is a probably-incomplete implementation of this issue: https://github.com/sumatrapdfreader/sumatrapdf/issues/3688

It's really intended to get some feedback on whether you all think it's a good idea or not.

PS: The configuration setting `EscToExit` is very surprising. Does *anybody* use it?