### PR TITLE
FileWatcher.cpp: continue monitoring a watched dir for changes even if a buffer overflow nullified one notification

### DIFF
--- a/src/utils/FileWatcher.cpp
+++ b/src/utils/FileWatcher.cpp
@@ -221,8 +221,11 @@ static void CALLBACK ReadDirectoryChangesNotification(DWORD errCode, DWORD bytes
         return;
     }
 
+    wd->startMonitoring = false;
+
     // This might mean overflow? Not sure.
-    if (!bytesTransfered) {
+    if (!bytesTransfered) {    
+        StartMonitoringDirForChanges(wd);
         return;
     }
 
@@ -250,7 +253,6 @@ static void CALLBACK ReadDirectoryChangesNotification(DWORD errCode, DWORD bytes
         notify = (FILE_NOTIFY_INFORMATION*)((char*)notify + nextOff);
     }
 
-    wd->startMonitoring = false;
     StartMonitoringDirForChanges(wd);
 
     for (char* f : changedFiles) {


### PR DESCRIPTION
In the function ReadDirectoryChangesNotification the parameter bytesTransfered may be zero, presumably indicating an overflow: the buffer was too small to contain all the change notifications that have accumulated, in which case these notifications are discarded. But we should keep on monitoring the watched dir for future changes as we would do when handling a normal notification. The original code didn't do that, and this is what I've fixed.

This change solves the problem of Sumatra not reloading PDF files in situations where other files in the same directory are being repeatedly changed very frequently, which creates a race condition that may lead to a buffer overflow. If needed I can provide more details on the circumstances under which I came across this problem.

Thanks!
