### PR TITLE
fix toc treeitem collapse ignored on tab switch  (fix #1721 and #3055)

### DIFF
--- a/src/TableOfContents.cpp
+++ b/src/TableOfContents.cpp
@@ -396,9 +396,7 @@ next:
 
 static void SetInitialExpandState(TocItem* item, Vec<int>& tocState) {
     while (item) {
-        if (tocState.Contains(item->id)) {
-            item->isOpenToggled = true;
-        }
+        item->isOpenToggled = tocState.Contains(item->id);
         SetInitialExpandState(item->child, tocState);
         item = item->next;
     }


### PR DESCRIPTION
item->isOpenToggled persist set to true once tocitem is opened (or closed if default state is open) and never returns to false after user close it (or open if default state is open). This hopefully fix the issue described in #1721 and #3055.