### PR TITLE
Rename 'done' field of SplitterMoveEvent to 'finishedDragging'

### DIFF
--- a/src/wingui/WinGui.cpp
+++ b/src/wingui/WinGui.cpp
@@ -2397,7 +2397,7 @@ LRESULT Splitter::WndProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) {
         ReleaseCapture();
         SplitterMoveEvent arg;
         arg.w = this;
-        arg.done = true;
+        arg.finishedDragging = true;
         onSplitterMove(&arg);
         HwndScheduleRepaint(hwnd);
         return 0;
@@ -2411,7 +2411,7 @@ LRESULT Splitter::WndProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) {
         if (hwnd == GetCapture()) {
             SplitterMoveEvent arg;
             arg.w = this;
-            arg.done = false;
+            arg.finishedDragging = false;
             onSplitterMove(&arg);
             if (!arg.resizeAllowed) {
                 curId = IDC_NO;

--- a/src/wingui/WinGui.h
+++ b/src/wingui/WinGui.h
@@ -444,12 +444,12 @@ enum class SplitterType {
 
 struct Splitter;
 
-// called when user drags the splitter ('done' is false) and when drag is finished ('done' is
+// called when user drags the splitter ('finishedDragging' is false) and when drag is finished ('finishedDragging' is
 // true). the owner can constrain splitter by using current cursor
 // position and setting resizeAllowed to false if it's not allowed to go there
 struct SplitterMoveEvent {
     Splitter* w = nullptr;
-    bool done = false; // TODO: rename to finishedDragging
+    bool finishedDragging = false;
     // user can set to false to forbid resizing here
     bool resizeAllowed = true;
 };


### PR DESCRIPTION
Rename the `done` field of `SplitterMoveEvent` to `finishedDragging` according to the `TODO` comment.