### PR TITLE
Initial clang-cl build

### DIFF
--- a/ext/mupdf_load_system_font.c
+++ b/ext/mupdf_load_system_font.c
@@ -463,6 +463,15 @@ static void extend_system_font_list(fz_context* ctx, const WCHAR* path) {
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 #define CURRENT_HMODULE ((HMODULE) & __ImageBase)
 
+// clang-cl notices the mismatch in function parameters with qsort
+// as _stricmp is int _stricmp(const char *string1, const char *string2);
+// and qsort expects int (*compar)(const void*,const void*)).
+static int stricmp_wrapper(const void* ptr1, const void* ptr2) {
+    const char* string1 = (const char*)ptr1;
+    const char* string2 = (const char*)ptr2;
+    return _stricmp(string1, string2);
+}
+
 static void create_system_font_list(fz_context* ctx) {
     WCHAR szFontDir[MAX_PATH];
     UINT cch;
@@ -491,7 +500,7 @@ static void create_system_font_list(fz_context* ctx) {
 #endif
 
     // sort the font list, so that it can be searched binarily
-    qsort((void*)fontlistMS.fontmap, (size_t)fontlistMS.len, sizeof(sys_font_info), _stricmp);
+    qsort((void*)fontlistMS.fontmap, (size_t)fontlistMS.len, sizeof(sys_font_info), stricmp_wrapper);
 
 #ifdef DEBUG
     // allow to overwrite system fonts for debugging purposes
@@ -506,7 +515,7 @@ static void create_system_font_list(fz_context* ctx) {
             if (entry)
                 *entry = fontlistMS.fontmap[i];
         }
-        qsort(fontlistMS.fontmap, fontlistMS.len, sizeof(sys_font_info), _stricmp);
+        qsort(fontlistMS.fontmap, fontlistMS.len, sizeof(sys_font_info), stricmp_wrapper);
     }
 #endif
 }

--- a/premake5.lua
+++ b/premake5.lua
@@ -197,6 +197,10 @@ workspace "SumatraPDF"
   filter "options:with-clang"
     location "vs2022-clang"
     toolset "clang"
+    buildoptions {"-fms-compatibility", "-fms-extensions", "-Wno-microsoft-include", "-march=x86-64-v3", "-maes"}
+    warnings "Off"
+    exceptionhandling "On"
+    rtti "Off"
   filter {}
 
   filter {"platforms:x32", "configurations:Release"}
@@ -255,8 +259,10 @@ workspace "SumatraPDF"
     -- "Unicode", TODO: breaks libdjuv?
   }
 
+  filter {'options:not with-clang'}
   exceptionhandling "Off"
   rtti "Off"
+  filter {}
 
   defines {
     "WIN32",
@@ -921,6 +927,10 @@ workspace "MakeLZSA"
   filter "options:with-clang"
     location "vs2022-clang"
     toolset "clang"
+    buildoptions {"-fms-compatibility", "-fms-extensions", "-Wno-microsoft-include", "-march=x86-64-v3", "-maes"}
+    warnings "Off"
+    exceptionhandling "On"
+    rtti "Off"
   filter {}
 
   filter {"platforms:x32", "configurations:Release"}
@@ -948,8 +958,10 @@ workspace "MakeLZSA"
     --"Unicode",
     "FatalCompileWarnings"
   }
+  filter "options:not with-clang"
   exceptionhandling "Off"
   rtti "Off"
+  filter{}
 
   defines {
     "WIN32",

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1436,7 +1436,7 @@ HMENU BuildMenuFromMenuDef(MenuDef* menuDef, HMENU menu, BuildMenuCtx* ctx) {
 
         if (cmdId == CmdOpenWithHtmlHelp && ctx) {
             WindowTab* tab = ctx->tab;
-            char* path = tab ? tab->filePath : nullptr;
+            char* path = tab ? tab->filePath.Get() : nullptr;
             AppendExternalViewersToMenu(menu, path);
         }
     }


### PR DESCRIPTION
An initial clang-cl build. For purposes of building with CI it is not ready as an architecture is set manually as clang notices some library functions have a dependency on specific features, and doesn't build without them, notably sse4.1 and aes. Both are old, but setting a specific feature set could be breaking and suboptimal, so needs further discussion. Currently clang-cl build is with warnings disabled. 
Passing qsort _stricmp directly is UB, though the way I resolved it currently probably isn't the prettiest. 
Sadly can't get it to build without exceptions on clang.