### PR TITLE
Ctrl+Tab in the most recent order

### DIFF
--- a/do/settings_gen_def.go
+++ b/do/settings_gen_def.go
@@ -372,6 +372,8 @@ var (
 			"3 is fullscreen, 4 is minimized"),
 		mkCompactStruct("WindowPos", windowPos,
 			"default position (can be on any monitor)").setStructName("Rect").setDoc("default position (x, y) and size (width, height) of the window"),
+		mkField("CtrlTabLastViewed", Bool, false,
+			"if true, Ctrl+Tab cycles through tabs in recently used order").setVersion("3.6"),
 
 		// file history and favorites
 		mkArray("FileStates", fileSettings,

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -432,6 +432,8 @@ struct GlobalPrefs {
     int windowState;
     // default position (can be on any monitor)
     Rect windowPos;
+    // if true, Ctrl+Tab cycles through tabs in recently used order
+    bool ctrlTabLastViewed;
     // information about opened files (in most recently used order)
     Vec<FileState*>* fileStates;
     // state of the last session, usage depends on RestoreSession
@@ -727,6 +729,7 @@ static const FieldInfo gGlobalPrefsFields[] = {
     {offsetof(GlobalPrefs, versionToSkip), SettingType::String, 0},
     {offsetof(GlobalPrefs, windowState), SettingType::Int, 1},
     {offsetof(GlobalPrefs, windowPos), SettingType::Compact, (intptr_t)&gRectInfo},
+    {offsetof(GlobalPrefs, ctrlTabLastViewed), SettingType::Bool, false},
     {offsetof(GlobalPrefs, fileStates), SettingType::Array, (intptr_t)&gFileStateInfo},
     {offsetof(GlobalPrefs, sessionData), SettingType::Array, (intptr_t)&gSessionDataInfo},
     {offsetof(GlobalPrefs, reopenOnce), SettingType::StringArray, 0},
@@ -743,7 +746,7 @@ static const StructInfo gGlobalPrefsInfo = {
     "\0ShowLinks\0ShowStartPage\0SidebarDx\0SmoothScroll\0TabWidth\0Theme\0TocDy\0ToolbarSize\0TreeFontName\0TreeFontSi"
     "ze\0UIFontSize\0UseSysColors\0UseTabs\0ZoomLevels\0ZoomIncrement\0\0FixedPageUI\0\0ComicBookUI\0\0ChmUI\0\0Annotat"
     "ions\0\0ExternalViewers\0\0ForwardSearch\0\0PrinterDefaults\0\0SelectionHandlers\0\0Shortcuts\0\0\0DefaultPassword"
-    "s\0UiLanguage\0VersionToSkip\0WindowState\0WindowPos\0FileStates\0SessionData\0ReopenOnce\0TimeOfLastUpdateCheck\0"
+    "s\0UiLanguage\0VersionToSkip\0WindowState\0WindowPos\0CtrlTabLastViewed\0FileStates\0SessionData\0ReopenOnce\0TimeOfLastUpdateCheck\0"
     "OpenCountWeek\0\0"};
 
 #endif


### PR DESCRIPTION
This change implements the https://github.com/sumatrapdfreader/sumatrapdf/discussions/2750 request via an advanced option CtrlTabLastViewed (default false). When CtrlTabLastViewed=true, then Ctrl+Tab behaves as in Firefox, going back to the most recent tab.
If Ctrl+Tab is pressed but Ctrl is not yet released then "CmdCommandPaletteOnlyTabs" is triggered so that the user can jump to another Tab, similar to Firefox's behaviour:
![SumatraPDF_oUhoicHX2r](https://github.com/user-attachments/assets/bee81e6f-599e-48c1-83c5-36ffc22396dd)
