### PR TITLE
Open Explorer and select file

### DIFF
--- a/src/ExternalViewers.cpp
+++ b/src/ExternalViewers.cpp
@@ -44,7 +44,7 @@ static ExternalViewerInfo gExternalViewers[] = {
         CmdOpenWithExplorer,
         "*",
         "explorer.exe",
-        R"("%d")",
+        R"(/select,"%1")",
         nullptr,
         nullptr,
     },


### PR DESCRIPTION
Instead of just opening the directory, this selects the file. This helps if you have a folder with lots of similarly named file.