### PR TITLE
Correct keyboard shortcuts for show page number and invert colors

### DIFF
--- a/docs/md/Keyboard-shortcuts.md
+++ b/docs/md/Keyboard-shortcuts.md
@@ -88,8 +88,8 @@ You can [customize keyboard shortcuts](Customizing-keyboard-shortcuts.md). Also 
 - `F11`, `Ctrl + Shift + L`, `f` - Enter / Exit full screen mode
 - `ESC` - exit full screen or presentation mode
 - mouse double click - exit full screen or presentation mode
-- `i` - invert colors in the document
-- `Shift + i` - show current page number
+- `Shift + i` - invert colors in the document
+- `i` - show current page number
 - `m` - show cursor position in document coordinates
 - `F8` - show/hide toolbar
 - `F9` - show/hide menu


### PR DESCRIPTION
- Updated the default keyboard shortcuts for the following commands:
  - 'Show current page number'
  - 'Show cursor position in document coordinates'
  - 'Invert colors in the document'

This update ensures that the shortcuts match the expected behavior, improving accessibility and user experience.