### PR TITLE
Move smooth scroll timers to a separate thread, instead of using `SetTimer`

### DIFF
--- a/src/Canvas.cpp
+++ b/src/Canvas.cpp
@@ -61,9 +61,6 @@ bool gNoFlickerRender = true;
 
 Kind kNotifAnnotation = "notifAnnotation";
 
-// Timer for mouse wheel smooth scrolling
-constexpr UINT_PTR kSmoothScrollTimerID = 6;
-
 // Smooth scrolling factor. This is a value between 0 and 1.
 // Each step, we scroll the needed delta times this factor.
 // Therefore, a higher factor makes smooth scrolling faster.
@@ -151,7 +148,7 @@ static void OnVScroll(MainWindow* win, WPARAM wp) {
     if (si.nPos != currPos || msg == SB_THUMBTRACK) {
         if (gGlobalPrefs->smoothScroll) {
             win->scrollTargetY = si.nPos;
-            SetTimer(win->hwndCanvas, kSmoothScrollTimerID, USER_TIMER_MINIMUM, nullptr);
+            SetEvent(win->scrollTimer);
         } else {
             win->AsFixed()->ScrollYTo(si.nPos);
         }
@@ -1211,7 +1208,7 @@ static void ZoomByMouseWheel(MainWindow* win, WPARAM wp) {
     win->dragStartPending = false;
     // Kill the smooth scroll timer when zooming
     // We don't want to move to the new updated y offset after zooming
-    KillTimer(win->hwndCanvas, kSmoothScrollTimerID);
+    ResetEvent(win->scrollTimer);
 
     short delta = GET_WHEEL_DELTA_WPARAM(wp);
     Point pt = HwndGetCursorPos(win->hwndCanvas);
@@ -1875,7 +1872,7 @@ static void OnTimer(MainWindow* win, HWND hwnd, WPARAM timerId) {
             int delta = target - current;
 
             if (delta == 0) {
-                KillTimer(hwnd, kSmoothScrollTimerID);
+                ResetEvent(win->scrollTimer);
             } else {
                 // logf("Smooth scrolling from %d to %d (delta %d)\n", current, target, delta);
 

--- a/src/Canvas.h
+++ b/src/Canvas.h
@@ -1,6 +1,9 @@
 /* Copyright 2022 the SumatraPDF project authors (see AUTHORS file).
    License: GPLv3 */
 
+// Timer for mouse wheel smooth scrolling
+constexpr UINT_PTR kSmoothScrollTimerID = 6;
+
 void UpdateDeltaPerLine();
 
 LRESULT CALLBACK WndProcCanvas(HWND, UINT, WPARAM, LPARAM);

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -215,7 +215,11 @@ struct MainWindow {
     // Seprate scroll thread for higher precision scrolling updates
     HANDLE scrollTimerThread = nullptr;
     bool scrollTimerCancelled = false;
+    // Scroll thread delta time (e.g. frame time) in ms
+    int scrollTimerDeltaTime = 0;
+
     HANDLE scrollTimer = nullptr;
+    HANDLE smoothscrollTimer = nullptr;
 
     // The target y offset for smooth scrolling.
     // We use a timer to gradually scroll there.

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -212,6 +212,11 @@ struct MainWindow {
 
     DocControllerCallback* cbHandler = nullptr;
 
+    // Seprate scroll thread for higher precision scrolling updates
+    HANDLE scrollTimerThread = nullptr;
+    bool scrollTimerCancelled = false;
+    HANDLE scrollTimer = nullptr;
+
     // The target y offset for smooth scrolling.
     // We use a timer to gradually scroll there.
     int scrollTargetY = 0;

--- a/src/Selection.cpp
+++ b/src/Selection.cpp
@@ -396,7 +396,7 @@ void OnSelectionStart(MainWindow* win, int x, int y, WPARAM) {
     }
 
     SetCapture(win->hwndCanvas);
-    SetTimer(win->hwndCanvas, SMOOTHSCROLL_TIMER_ID, SMOOTHSCROLL_DELAY_IN_MS, nullptr);
+    SetEvent(win->smoothscrollTimer);
     ScheduleRepaint(win, 0);
 }
 
@@ -404,7 +404,7 @@ void OnSelectionStop(MainWindow* win, int x, int y, bool aborted) {
     if (GetCapture() == win->hwndCanvas) {
         ReleaseCapture();
     }
-    KillTimer(win->hwndCanvas, SMOOTHSCROLL_TIMER_ID);
+    ResetEvent(win->smoothscrollTimer);
 
     // update the text selection before changing the selectionRect
     if (MouseAction::SelectingText == win->mouseAction) {

--- a/src/Selection.h
+++ b/src/Selection.h
@@ -2,8 +2,7 @@
    License: GPLv3 */
 
 #define SMOOTHSCROLL_TIMER_ID 2
-#define SMOOTHSCROLL_DELAY_IN_MS 20
-#define SMOOTHSCROLL_SLOW_DOWN_FACTOR 10
+#define SMOOTHSCROLL_FACTOR 10
 
 /* Represents selected area on given page */
 struct SelectionOnPage {


### PR DESCRIPTION
Potentially addresses #4122

**Note.** To avoid confusion, I'm going to refer to middle-click scroll as "auto scroll." And I'm going to refer to smoothly animated/interpolated scrolling (enabled by the `SmoothScroll=true` config) as "interpolated scroll." In the code, "auto scroll" is referred to as `SMOOTHSCROLL`, while "interpolated scroll" is referred to as `smoothScroll`. This could be confusing, which is why I call them "auto scroll" and "interpolated scroll."

---

Discussion #4122 complains that "auto scroll" is too scratchy, and I noticed that this is probably because it uses `SetTimer()`. Also, "interpolated scroll" uses `SetTimer()` as well. An issue is that `SetTimer()` allows a minimum of 10ms/100fps (according to the [docs](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-settimer), but it seems the true minimum is closer to  16ms/60fps in my testing). Many displays run at much higher than 100Hz (e.g. mine runs at 144Hz), so this results in a very scratchy appearance.

A relatively non-intrusive solution is to replace the timer with a thread (see `ScrollTimerThread()`) which sends `WM_TIMER` messages to the canvas window. Since we use our own thread instead of `SetTimer()`, we can run at the monitor's refresh rate, instead of a capped 10ms/100fps. Note that using this method, not very much code needs changing. We still use `WM_TIMER` messages, which can be handled in the exact same way as before. The only difference is that instead of `SetTimer()`/`KillTimer()`, we have to call `SetEvent()`/`ResetEvent()` on an Event object which the thread is waiting on. Also, we have to account for the delta time (Δt) so that scrolling isn't faster/slower depending on refresh rate (i.e. for "auto scroll," a 144Hz monitor and a 60Hz monitor should have the same scroll speed).

---

Note that this is a draft PR because I just wanted to show a proof-of-concept that improves scrolling on high-refresh displays, in case it is helpful at all. It's not perfect, since `WM_TIMER` messages are [low-priority](https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-timer#remarks). But it's relatively simple and non-intrusive, which is why I wanted to bring it up.