### PR TITLE
Fix: Possible Vulnerability in zlib Library

### DIFF
--- a/ext/zlib/contrib/infback9/inftree9.c
+++ b/ext/zlib/contrib/infback9/inftree9.c
@@ -54,8 +54,7 @@ unsigned short FAR *work;
     code FAR *next;             /* next available space in table */
     const unsigned short FAR *base;     /* base value table to use */
     const unsigned short FAR *extra;    /* extra bits table to use */
-    int end;                    /* use base and extra for symbol > end */
-    unsigned short count[MAXBITS+1];    /* number of codes of each length */
+    unsigned match;             /* use base and extra for symbol >= match */    unsigned short count[MAXBITS+1];    /* number of codes of each length */
     unsigned short offs[MAXBITS+1];     /* offsets in table for each length */
     static const unsigned short lbase[31] = { /* Length codes 257..285 base */
         3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17,
@@ -175,19 +174,17 @@ unsigned short FAR *work;
     switch (type) {
     case CODES:
         base = extra = work;    /* dummy value--not used */
-        end = 19;
+        match = 20;
         break;
     case LENS:
         base = lbase;
-        base -= 257;
         extra = lext;
-        extra -= 257;
-        end = 256;
+        match = 257;
         break;
     default:            /* DISTS */
         base = dbase;
         extra = dext;
-        end = -1;
+        match = 0;
     }
 
     /* initialize state for loop */
@@ -210,13 +207,13 @@ unsigned short FAR *work;
     for (;;) {
         /* create table entry */
         this.bits = (unsigned char)(len - drop);
-        if ((int)(work[sym]) < end) {
+        if (work[sym] + 1 < match) {
             this.op = (unsigned char)0;
             this.val = work[sym];
         }
-        else if ((int)(work[sym]) > end) {
-            this.op = (unsigned char)(extra[work[sym]]);
-            this.val = base[work[sym]];
+        else if (work[sym] >= match) {
+            this.op = (unsigned char)(extra[work[sym] - match]);
+            this.val = base[work[sym] - match];
         }
         else {
             this.op = (unsigned char)(32 + 64);         /* end of block */


### PR DESCRIPTION
## Issue Details
The function inflate_table9() in this repository is nearly identical to inflate_table() from zlib.
The original function was patched due to a vulnerability identified in https://github.com/madler/zlib/commit/6a043145ca6e9c55184013841a67b2fef87e44c0.
The same issue exists in this repository's function but remains unpatched.

## Proposed Fix
This PR applies the same patch as the one in zlib to eliminate the vulnerability.

## References
CVE: [CVE-2016-9840](https://nvd.nist.gov/vuln/detail/CVE-2016-9840)
Original Fix: [Original Fix](https://github.com/madler/zlib/commit/6a043145ca6e9c55184013841a67b2fef87e44c0)