### PR TITLE
Partial Revert of "fix color invert in default theme" (fixes #4073)

### DIFF
--- a/src/Theme.cpp
+++ b/src/Theme.cpp
@@ -203,6 +203,13 @@ COLORREF ThemeDocumentColors(COLORREF& bg) {
         return text;
     }
 
+    // if user did change those colors in advanced settings, respect them
+    bool userDidChange = text != kColBlack || bg != kColWhite;
+    if (userDidChange) {
+        std::swap(text, bg);
+        return text;
+    }
+
     // default colors
     if (gCurrentTheme == gThemeLight) {
         std::swap(text, bg);


### PR DESCRIPTION
Since https://github.com/sumatrapdfreader/sumatrapdf/commit/5adadc279436ed92195fe846ea0b3f8baad7fc59 as reported in #4073:
> **SumatraPDF version** 3.6.15949 pre-release or later
> 
> **Describe the bug** I'm using the Darker theme UI, with black set to full black and white set to low contrast.
> 
> Theme = Darker FixedPageUI [ TextColor = #000000 BackgroundColor = #bbbbbb
> 
> When using the Invert Colors, if the Theme is Dark/Darker and not Light, the TextColor/BackgroundColor provided by the Theme will be used, not the Color value I set.
> 
> If TextColor and BackgroundColor are not the default and are custom set by the user, I would like them to respect the Color value regardless of the Theme.

The code for `userDidChange` was erroneously removed, which was unnecessary to fix the bug reported in #4030.