### PR TITLE
Check image size when reading targa file

### DIFF
--- a/ext/libjpeg-turbo/rdtarga.c
+++ b/ext/libjpeg-turbo/rdtarga.c
@@ -363,7 +363,8 @@ start_input_tga (j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
   if (cmaptype > 1 ||		/* cmaptype must be 0 or 1 */
       source->pixel_size < 1 || source->pixel_size > 4 ||
       (UCH(targaheader[16]) & 7) != 0 || /* bits/pixel must be multiple of 8 */
-      interlace_type != 0)	/* currently don't allow interlaced image */
+      interlace_type != 0 ||	/* currently don't allow interlaced image */
+      width == 0 || height == 0)  /* image width/height must be non-zero */
     ERREXIT(cinfo, JERR_TGA_BADPARMS);
   
   if (subtype > 8) {


### PR DESCRIPTION
**Description**
This PR throws an error when image width or height is 0 when reading a targa file in ext/libjpeg-turbo/rdtarga.c which was cloned from libjpeg-turbo but did not receive the patch applied in the original repository. The original issue was reported and fixed under [libjpeg-turbo/libjpeg-turbo@82923eb](https://github.com/libjpeg-turbo/libjpeg-turbo/commit/82923eb93a2eacf4a593e00e3e672bbb86a8a3a0).