### PR TITLE
Make splitters respect theme color

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -652,8 +652,8 @@ void UpdateControlsColors(MainWindow* win) {
 
     // logfa("retrieved doc colors in tree control: 0x%x 0x%x\n", treeTxtCol, treeBgCol);
 
-    COLORREF splitterCol = GetSysColor(COLOR_BTNFACE);
-    bool flatTreeWnd = false;
+    COLORREF splitterCol = ThemeControlBackgroundColor();
+    bool flatTreeWnd = true;
 
     {
         auto tocTreeView = win->tocTreeView;

--- a/src/wingui/WinGui.cpp
+++ b/src/wingui/WinGui.cpp
@@ -2461,7 +2461,7 @@ HWND TreeView::Create(const CreateArgs& argsIn) {
     args.className = WC_TREEVIEWW;
     args.parent = argsIn.parent;
     args.font = argsIn.font;
-    args.style = WS_CHILD | WS_VISIBLE | WS_TABSTOP;
+    args.style = WS_CHILD | WS_VISIBLE | WS_TABSTOP | WS_BORDER;
     args.style |= TVS_HASBUTTONS | TVS_HASLINES | TVS_LINESATROOT | TVS_SHOWSELALWAYS;
     args.style |= TVS_TRACKSELECT | TVS_NOHSCROLL | TVS_INFOTIP;
     args.exStyle = argsIn.exStyle | TVS_EX_DOUBLEBUFFER;


### PR DESCRIPTION
to reduce light elements in darker themes