### PR TITLE
Fix single page print with modern dialog

### DIFF
--- a/src/Print.cpp
+++ b/src/Print.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 the SumatraPDF project authors (see AUTHORS file).
+/* Copyright 2025 the SumatraPDF project authors (see AUTHORS file).
    License: GPLv3 */
 
 #include "utils/BaseUtil.h"
@@ -901,7 +901,16 @@ void PrintCurrentFile(MainWindow* win, bool waitForCompletion) {
     }
 
     if (pdex.Flags & PD_CURRENTPAGE) {
-        PRINTPAGERANGE pr = {(DWORD)dm->CurrentPageNo(), (DWORD)dm->CurrentPageNo()};
+        PRINTPAGERANGE pr;
+        if (pdex.nPageRanges == 1 && pdex.lpPageRanges[0].nFromPage == pdex.lpPageRanges[0].nToPage) {
+            // Unified Print Dialog (which doesn't have a "Current page" option)
+            // sets PD_CURRENTPAGE when the custom range contains one page (2 or 2-2)
+            // with nFromPage and nToPage equal to the chosen page.
+            // PD_PAGENUMS isn't set in that case.
+            pr = pdex.lpPageRanges[0];
+        } else {
+            pr = {(DWORD)dm->CurrentPageNo(), (DWORD)dm->CurrentPageNo()};
+        }
         ranges.Append(pr);
     } else if (win->CurrentTab()->selectionOnPage && (pdex.Flags & PD_SELECTION)) {
         printSelection = true;


### PR DESCRIPTION
Fixes #3453, fixes #4235, fixes #4779, fixes #4817.

Setting a single page print range in modern UI results in SumatraPDF printing the current page.
It's caused by a change of behavior between legacy and modern print dialog, which, like you identified,
sets flags in a non expected way.

Here are flags hex values in different scenarios:

<ins>Single page range (2 or 2-2)</ins>
Legacy 0x00040006
Modern 0x00440014 -> Causing the issue because `PD_CURRENTPAGE` is set.

<ins>Other ranges</ins>
Legacy 0x00040006
Modern 0x00040016

<ins>Current page</ins>
Legacy 0x00440004
Not available in modern

<ins>All pages</ins>
Legacy 0x00040004
Modern 0x00040014

So, modern dialog sets `PD_CURRENTPAGE` instead of `PD_PAGENUMS` when a single page range is entered,
`lpPageRanges` containing the custom range, with `nFromPage` and `nToPage` set to the chosen page.

About code, note that `nPageRanges == 1` check is added for precaution,
it is always equal to 1 when legacy and modern dialogs set `PD_CURRENTPAGE`.