### PR TITLE
Enable multiple instances when using unique -appdata command line option

### DIFF
--- a/src/SumatraStartup.cpp
+++ b/src/SumatraStartup.cpp
@@ -402,11 +402,11 @@ static void SetupCrashHandler() {
 }
 
 static HWND FindPrevInstWindow(HANDLE* hMutex) {
-    // create a unique identifier for this executable
+    // create a unique identifier for this executable and appdata combination
     // (allows independent side-by-side installations)
-    TempStr exePath = GetSelfExePathTemp();
-    str::ToLowerInPlace(exePath);
-    u32 hash = MurmurHash2(exePath, str::Len(exePath));
+    TempStr combinedPath = str::Join(GetSelfExePathTemp(), "|", GetAppDataDirTemp());
+    str::ToLowerInPlace(combinedPath);
+    u32 hash = MurmurHash2(combinedPath, str::Len(combinedPath));
     TempStr mapId = str::FormatTemp("SumatraPDF-%08x", hash);
 
     int retriesLeft = 3;


### PR DESCRIPTION
When running multiple instances with -appdata pointing to different directory and using "useTabs" setting then only first instance settings are applied.
Example use case is using two shortcuts with different settings files to keep open tabs organised in two instances. If first has for example work related pdf tabs and second has personal tabs open then whichever process is first opened only that restores its open tabs, second shortcut execution only opens new window with 0 tabs not a new process.

After change the -appdata value is always incorporated in hash that is used in instance detection mutex name.