### PR TITLE
Navigate to selected bookmark

### DIFF
--- a/src/Favorites.cpp
+++ b/src/Favorites.cpp
@@ -775,14 +775,13 @@ void RememberFavTreeExpansionStateForAllWindows() {
     }
 }
 
-#if 0
-static void FavTreeItemClicked(TreeClickEvent* ev) {
-    ev->didHandle = true;
-    MainWindow* win = FindMainWindowByHwnd(ev->w->hwnd);
-    ReportIf(!win);
-    GoToFavForTreeItem(win, ev->treeItem);
+static void FavTreeItemClicked(TreeView::ClickEvent* ev) {
+    if (ev->treeItem == ev->treeView->GetSelection()) {
+        MainWindow* win = FindMainWindowByHwnd(ev->treeView->hwnd);
+        ReportIf(!win);
+        GoToFavForTreeItem(win, ev->treeItem);
+    }
 }
-#endif
 
 static void FavTreeSelectionChanged(TreeView::SelectionChangedEvent* ev) {
     MainWindow* win = FindMainWindowByHwnd(ev->treeView->hwnd);
@@ -914,7 +913,7 @@ void CreateFavorites(MainWindow* win) {
     treeView->onContextMenu = fn;
     treeView->onSelectionChanged = MkFunc1Void(FavTreeSelectionChanged);
     treeView->onKeyDown = MkFunc1Void(TocTreeKeyDown2);
-    // treeView->onClick = FavTreeItemClicked;
+    treeView->onClick = MkFunc1Void(FavTreeItemClicked);
     // treeView->onChar = TocTreeCharHandler;
     // treeView->onMouseWheel = TocTreeMouseWheelHandler;
 


### PR DESCRIPTION
In this pull request I made FavTreeItemClicked working for currently selected tree item.

When there’s only one bookmark, you can navigate to it only once because navigation to the bookmark page happens in the FavTreeSelectionChanged callback. This callback is triggered only when a different tree element is selected.

In the code, there’s also an onClick handler, but it was commented out in this commit: https://github.com/sumatrapdfreader/sumatrapdf/commit/32b298161e6286d23d8253d874f9f2aca38c65ef

because of two related issues.:
https://github.com/sumatrapdfreader/sumatrapdf/issues/1716 https://github.com/sumatrapdfreader/sumatrapdf/issues/2202