### PR TITLE
In AppSettings.cpp when gDontSaveSettings is set to true, skip doing anything when SaveSettings is called.

### DIFF
--- a/src/AppSettings.cpp
+++ b/src/AppSettings.cpp
@@ -345,11 +345,12 @@ static void RememberSessionState() {
 // added or removed from gFileHistory (in order to keep
 // the list of recently opened documents in sync)
 bool SaveSettings() {
-    if (!gDontSaveSettings) {
+    if (gDontSaveSettings) {
         // if we are exiting the application by File->Exit,
         // OnMenuExit will have called SaveSettings() already
         // and we skip the call here to avoid saving incomplete session info
         // (because some windows might have been closed already)
+        return true;
     }
 
     // don't save preferences without the proper permission


### PR DESCRIPTION
In commit 0e805bf a guard clause is added to `AppSettings.cpp` that is supposed to skip running `SaveSettings` multiple times when `OnMenuExit` is used. The if statement does not return so setting `gDontSaveSettings` to true or false has no effect on whether the logic of `SaveSettings` gets executed or not.

This PR adds the return statement so the logic works as intended when `gDontSaveSettings` is set to true. 

Considering that this isn't being used, it might be better to remove all the references to `gDontSaveSettings`, instead of accepting this PR, if the current behaviour is good enough.