### PR TITLE
A few typos and omissions in docs

### DIFF
--- a/docs/md/Advanced-options-settings.md
+++ b/docs/md/Advanced-options-settings.md
@@ -567,5 +567,5 @@ The components are hex values (ranging from 00 to FF) and stand for:
 - `bb` : blue component
 - `aa` : alpha (transparency) component
 
-For example #ff0000 means red color. #ff00007f is half-transparent red.
+For example `#ff0000` means red color. `#7fff0000` is half-transparent red.
 

--- a/docs/md/Command-line-arguments.md
+++ b/docs/md/Command-line-arguments.md
@@ -61,7 +61,7 @@ Anything that is not recognized as a known option is interpreted as a file path 
 
 ## Options related to forward/inverse search (for LaTeX editors)
 
-- `-forward-search "<sourcepath>" <line> "<pdfpath>"`: performs a forward search from a LaTeX source file to a loaded PDF document (using PdfSync or SyncTeX). This is an alternative to the ForwardSearch DDE command. E.g. -forward-search "/path/to/main.tex" 123 "/path/to/main.pdf" highlights all text related to line 123 in main.tex.
+- `-forward-search "<sourcepath>" <line> "<pdfpath>"`: performs a forward search from a LaTeX source file to a loaded PDF document (using PdfSync or SyncTeX). This is an alternative to the ForwardSearch DDE command. E.g. `-forward-search "/path/to/main.tex" 123 "/path/to/main.pdf"` highlights all text related to line 123 in main.tex.
 - `-reuse-instance` : tells an already open SumatraPDF to load the indicated files. If there are several running instances, behavior is undefined. Only needed when communicating with SumatraPDF through DDE (use the ReuseInstance setting instead otherwise).
 - `-inverse-search <command-line>` : sets the command line to be used for performing an inverse search from a PDF document (usually back to a LaTeX source file). The inverse search command line can also be set from the Setting dialog. Use the variable %f for the current filename and %l for the current line.
 [Deprecated]: This setting is exposed in the Options dialog after the first PDF document with corresponding .synctex or .pdfsync file has been loaded. Alternatively, use the corresponding advanced setting instead.
@@ -72,7 +72,7 @@ Anything that is not recognized as a known option is interpreted as a file path 
 
 - `-console` : Opens a console window alongside SumatraPDF for accessing (MuPDF) debug output.
 - `-stress-test <path> [file-filter] [range] [cycle-count]`
-    - Renders all pages of the indicated file/directory for stability and performance testing. E.g.:
+    : Renders all pages of the indicated file/directory for stability and performance testing. E.g.:
 
     ```
     -stress-test file1.pdf 25x
@@ -88,12 +88,10 @@ Anything that is not recognized as a known option is interpreted as a file path 
 
 The following options just set values in the settings file and may be removed in any future version:
 
-- `-bg-color <hexcolor>` : changes the yellow background color to a different color. See e.g. [html-color-codes.info](https://html-color-codes.info/) for a way to generate the hexcode for a color. E.g. `-bg-color #999999` changes the color to gray.
-[Deprecated]: Use [MainWindowBackground](https://www.sumatrapdfreader.org/settings/settings.html#MainWindowBackground) setting instead.
+- `-bg-color <hexcolor>` : changes the yellow background color to a different color. See e.g. [html-color-codes.info](https://html-color-codes.info/) for a way to generate the hexcode for a color. E.g. `-bg-color #999999` changes the color to gray. [Deprecated]: Use [MainWindowBackground](https://www.sumatrapdfreader.org/settings/settings.html#MainWindowBackground) setting instead.
 - `-esc-to-exit` : enables the Escape key to quit SumatraPDF. Deprecated: Use the [EscToExit](https://www.sumatrapdfreader.org/settings.html#EscToExit) setting instead.
 - `-set-color-range <text-hexcolor> <background-hexcolor>` : Uses the given two colors for foreground and background and maps all other colors used in a document in between these two. E.g. `-set-color-range #dddddd #333333` displays soft white text on a dark gray background. [Deprecated]: Use the TextColor and BackgroundColor settings for FixedPageUI instead.
-- `-lang <language-code>` : sets the UI language. See [/scripts/trans_langs.py] (https://github.com/sumatrapdfreader/sumatrapdf/blob/master/scripts/trans_langs.py) for the list of available language codes. E.g. -lang de. [Deprecated]: Use the `UiLanguage` setting instead.
-- `-manga-mode <mode>` : enables or disables "Manga mode" for reading (mainly Japanese) comic books from right to left. Mode must be "true" or 1 for enabling and "false" or 0 for disabling this feature.
+- `-lang <language-code>` : sets the UI language. See [/scripts/trans_langs.py] (https://github.com/sumatrapdfreader/sumatrapdf/blob/master/scripts/trans_langs.py) for the list of available language codes. E.g. `-lang de`. [Deprecated]: Use the `UiLanguage` setting instead.
+- `-manga-mode <mode>` : enables or disables "Manga mode" for reading (mainly Japanese) comic books from right to left. Mode must be "true" or 1 for enabling and "false" or 0 for disabling this feature. Deprecated: Use the [CbxMangaMode](https://www.sumatrapdfreader.org/settings.html#ComicBookUI_CbxMangaMode) setting for ComicBookUI instead.
 - `-invert-colors`
 
-Deprecated: Use the [CbxMangaMode](https://www.sumatrapdfreader.org/settings.html#ComicBookUI_CbxMangaMode) setting for ComicBookUI instead.

--- a/docs/md/Corrupted-installation.md
+++ b/docs/md/Corrupted-installation.md
@@ -19,7 +19,7 @@ There are 2 possible problems:
 
 If you want to place SumatraPDF in any location, under any name, use the self-contained portable flavor.
 
-If you insist on using the installable version, just install it. The installer will run if it has `-install` in the name of the .exe (which it will if you download [official build](https://www.sumatrapdfreader.org/download-free-pdf-viewer)).
+If you insist on using the installable version, just install it. The installer will run if it has `-install` in the name of the `.exe` (which it will if you download [official build](https://www.sumatrapdfreader.org/download-free-pdf-viewer)).
 
 If you rename the `.exe`, you can force running the installer with `-install` option.
 

--- a/docs/md/Customize-search-translation-services.md
+++ b/docs/md/Customize-search-translation-services.md
@@ -19,7 +19,7 @@ You can also use command palette (`Ctrl + K`):
 - `Ctrl + K` to open command palette
 - type e.g. `deepl` to find `Translate with DeepL` command
 
-![Untitled](img/cmd-palette-translate.png)
+![Using Command Palette](img/cmd-palette-translate.png)
 
 - press `Enter` (or double-click with mouse) to execute the action
 

--- a/docs/md/Debugging-Sumatra.md
+++ b/docs/md/Debugging-Sumatra.md
@@ -45,11 +45,8 @@ Here are the steps to follow if Sumatra hangs
 2. start WinDBG.exe
 3. use File/Attach to process (F6) and select SumatraPDF.exe from the
 4. In WinDBG, type:
-
-7.1) `.sympath+ SRV*c:\symbols*https://msdl.microsoft.com/download/symbols`
-
-7.2) `~*kb`
-
-7.3) `lmf`
+    - `.sympath+ SRV*c:\symbols*https://msdl.microsoft.com/download/symbols`
+    - `~*kb`
+    - `lmf`
 
 Attach the output to bug report.

--- a/docs/md/Editing-annotations.md
+++ b/docs/md/Editing-annotations.md
@@ -88,7 +88,7 @@ To change default color for highlight annotation (created with keyboard shortcut
 
 This is a first version of annotation editing. We don't yet support all annotation types and can't do everything that other PDF editing apps can do.
 
-The future will be driven by your feedback. If there are features missing or there are better ways of doing things, let me know in the forum [https://forum.sumatrapdfreader.org/](https://forum.sumatrapdfreader.org/)
+The future will be driven by your feedback. If there are features missing or there are better ways of doing things, let me know in [Discussions](https://github.com/sumatrapdfreader/sumatrapdf/discussions)
 
 When providing feedback:
 

--- a/docs/md/LaTeX-integration.md
+++ b/docs/md/LaTeX-integration.md
@@ -26,8 +26,8 @@ Launch SumatraPDF from TeXStudio enabling forward and backward search:
 
 Configure viewer in [output profiles](https://texniccenter.sourceforge.net/configuration.html#viewer-tab).
 
-- press Alt+F7 (Build > Define Output Profiles)
-- for any one of the PDF Profiles e.g. LaTeX > PDF
+- press `Alt + F7` (`Build` > `Define Output Profiles`)
+- for any one of the PDF Profiles e.g. `LaTeX` > `PDF`
 - for Executable path it should have something like:
   - `C:\Program Files\SumatraPDF\SumatraPDF.exe -inverse-search "\"C:\Program Files (x86)\TeXnicCenter\TeXnicCenter.exe\" /ddecmd \"[goto('%f','%l')]\""`
   - `SumatraPDF.exe` path might be different on your computer
@@ -50,11 +50,11 @@ UseTabs = true
 
 Now a double click in the PDF should take you back to TeXnicCenter either in an included file or the main file. IF not, check the syntax of the InverseSearchCmdLine = matches YOUR location for TeXnicCenter
 
-Back in the editor press Alt+F7 (Build > Define Output Profiles) and for each of the PDF options select viewer
+Back in the editor press `Alt + F7` (`Build` > `Define Output Profiles`) and for each of the PDF options select viewer
 
-In the 1Executable path1 section REMOVE anything after the .exe
+In the `Executable path` section REMOVE anything after the .exe
 
-In the 1View project's Output1 select `Command line argument` and check it is `"%bm.pdf"`
+In the `View project's Output` select `Command line argument` and check it is `"%bm.pdf"`
 
 In Forward search change it to `-forward-search "%Wc" %l "%bm.pdf"`
 

--- a/docs/md/Set-as-default-PDF-viewer.md
+++ b/docs/md/Set-as-default-PDF-viewer.md
@@ -18,7 +18,7 @@ In File Explorer:
 
 From the list, choose `SumatraPDF` and check `Always use this app to open .pdf files`:
 
-![choose_app.png](img/choose_app.png)
+![Choose App](img/choose_app.png)
 
 ## Using Default apps system settings
 
@@ -28,11 +28,11 @@ Unfortunately the details differ between Windows updates.
 
 Launch `Default app` section in settings app, e.g. use `Windows logo` hot-key to launch system-wide search, type `default apps` and click on `Default apps` search result to launch settings app.
 
-![Untitled](img/default-apps.png)
+![Default apps](img/default-apps.png)
 
 In Default apps type `.pdf` for file extension:
 
-![Settings](img/settings-app.png)
+![Default apps Settings](img/settings-app.png)
 
 Click on current default PDF application (`Microsoft Edge` in this example) and select `SumatraPDF`:
 

--- a/docs/md/Submit-crash-report.md
+++ b/docs/md/Submit-crash-report.md
@@ -1,4 +1,4 @@
-# Submit crash report`
+# Submit crash report
 
 Please help us fix SumatraPDF crashes.
 

--- a/docs/md/Uninstalling-SumatraPDF.md
+++ b/docs/md/Uninstalling-SumatraPDF.md
@@ -28,7 +28,7 @@ On Windows 10 / 11:
 
 ## What if the above doesn't help?
 
-What if you still have questions? You can use the [forums](https://forum.sumatrapdfreader.org/) to ask for additional help.
+What if you still have questions? You can use [Discussions](https://github.com/sumatrapdfreader/sumatrapdf/discussions) to ask for additional help.
 
 However, in order for someone to help you, you need to provide the following information:
 

--- a/docs/md/Version-history.md
+++ b/docs/md/Version-history.md
@@ -10,7 +10,7 @@
 - sort thumbnails on home page by most recently used date. Set advanced setting `HomePageSortByFrequentlyRead = true` to revert to pre-3.6 behavior of sorting by frequency of use.
 - support brotli compression in PDF files
 - in Command Palette, if you start search with `:` we show everything (like in 3.5)
-- in Command Palette, when viewing opened files history (#), you can press Delete to remove the entry from history
+- in Command Palette, when viewing opened files history (`#`), you can press Delete to remove the entry from history
 - improved zooming:
   - zooming with pinch touch screen gesture or with ctrl + scroll wheel now zooms around the mouse position and does continuous zoom levels. Used to zoom around top-left corner and progress fixed zoom levels shown in menu
 - include manual (`F1` to launch browser with documentation)
@@ -24,7 +24,7 @@
   - `CmdInvokeInverseSearch`
   - `CmdMoveTabRight` (`Ctrl + Shift + PageUp`), `CmdMoveTabLeft` (`Ctrl + Shift + PageDown`) to move tabs left / right, like in Chrome
 - add ability to provide arguments to some commands when creating bindings in `Shortcuts`:
-  - CmdCreateAnnot\* commands take a color argument, `openedit` to automatically open edit annotations window when creating an annotation, `copytoclipboard` to copy selection to clipboard and `setcontent` to set contents of annotation to selection
+  - `CmdCreateAnnot*` commands take a color argument, `openedit` to automatically open edit annotations window when creating an annotation, `copytoclipboard` to copy selection to clipboard and `setcontent` to set contents of annotation to selection
   - `CmdScrollDown`, `CmdScrollUp` : integer argument, how many lines to scroll
   - `CmdGoToNextPage`, `CmdGoToPrevPage` : integer argument, how many pages to advance
   - `CmdNextTabSmart`, `CmdPrevTabSmart` (`Smart Tab Switch`), shortcut: `Ctrl + Tab`, `Ctrl + Shift + Tab`
@@ -46,7 +46,7 @@
 - change: `CmdCreateAnnotHighlight` etc. no longer copies selection to clipboard by default. To get that behavior back, you can use `copytoclipboard` argument [instead](Commands.md#cmdcreateannothighlight-and-other-cmdcreateannot).
 - change: `Ctrl + Tab` is now `CmdNextTabSmart`, was `CmdNextTab`. `Ctrl + Shift + Tab` is now `CmdPrevTabSmart`, was `CmdPrevTab`. You can [re-bind it](Customizing-keyboard-shortcuts.md) if you prefer old behavior
 - `CmdCommandPalette` takes optional `mode` argument: `@` for tab selection, `#` for selecting from file history and `>` for commands.
-- command palette no longer shows combined tabs/file history/commands. `CmdCommandPalette` only shows commands. Because of that removed `CmdCommandPaletteNoFiles` because now ``CmdCommandPalette` behaves like it
+- command palette no longer shows combined tabs/file history/commands. `CmdCommandPalette` only shows commands. Because of that removed `CmdCommandPaletteNoFiles` because now `CmdCommandPalette` behaves like it
 - removed `CmdCommandPaletteOnlyTabs`, replaced by `CmdCommandPaletteNoFiles @`
 - `Ctrl + Shift + K` no longer active, use `Ctrl + K`. You can restore this shortcut by binding it to `CmdCommandPalette >` command.
 - add `Name` field for shortcuts. If given, the command will show up in Command Palette (`Ctrl + K`)
@@ -146,7 +146,7 @@
 - `i` keyboard shortcuts inverts document colors `Shift + i` does what `i` used to do i.e. show page number
 - `u` and `Shift + u` keyboard shortcuts adds underline annotation for currently selected text
 - `Delete` / `Backspace` keyboard shortcuts delete an annotation under mouse cursor
-- support .svg files
+- support `.svg` files
 - faster scrolling with mouse wheel when cursor over scrollbar
 - add `-search` cmd-line option and `[Search("<file>", "<search-term>")]` DDE command
 - a way to get list of used fonts in properties window
@@ -159,7 +159,7 @@
 
 ## 3.3.2 (2021-07-19)
 
-- restore showing Table Of Contents for .chm files
+- restore showing Table Of Contents for `.chm` files
 - fix crashes
 
 ## 3.3.1 (2021-07-14)
@@ -183,8 +183,8 @@
 Minor improvements and bug-fixes:
 
 - advanced setting to change font size in bookmarks / favorites tree view e.g. `TreeFontSize = 12`
-- support newer versions of ghostscript (≥ 9.54) for opening .ps files
-- support jpeg-xr images in .xps files
+- support newer versions of ghostscript (≥ 9.54) for opening `.ps` files
+- support jpeg-xr images in `.xps` files
 - restore tooltips (regression in 3.2)
 - update mupdf to latest version
 - make silent installation always silent
@@ -245,10 +245,10 @@ This release no longer supports Windows XP. Latest version that support XP is 3.
 - add support for LZMA and PPMd compression in CBZ comic books
 - allow saving Comic Book files as PDF
 - swapped keybindings:
-  - F11 : Fullscreen mode (still also Ctrl+Shift+L)
-  - F5 : Presentation mode (also Shift+F11, still also Ctrl+L)
-- added a document measurement UI. Press 'm' to start. Keep pressing 'm' to change measurement units
-- new advanced settings: FullPathInTitle, UseSysColors (no longer exposed through the Options dialog), UseTabs
+  - `F11` : Fullscreen mode (still also `Ctrl + Shift + L`)
+  - `F5` : Presentation mode (also `Shift + F11`, still also `Ctrl + L`)
+- added a document measurement UI. Press `m` to start. Keep pressing `m` to change measurement units
+- new advanced settings: `FullPathInTitle`, `UseSysColors` (no longer exposed through the Options dialog), `UseTabs`
 - replaced non-free UnRAR with a free RAR extraction library. If some CBR files fail to open for you, download unrar.dll from https://www.rarlab.com/rar_add.htm and place it alongside SumatraPDF.exe
 - deprecated browser plugin. We keep it if it was installed in earlier version
 
@@ -265,20 +265,20 @@ This release no longer supports Windows XP. Latest version that support XP is 3.
 
 - 2 page view for ebooks
 - new keybindings:
-  - Ctrl+PgDn, Ctrl+Right : go to next page
-  - Ctrl+PgUp, Ctrl+Left : go to previous page
+  - `Ctrl + PgDn`, `Ctrl + Right` : go to next page
+  - `Ctrl + PgUp`, `Ctrl + Left` : go to previous page
 - 10x faster ebook layout
 - support JP2 images
-- new **[advanced settings](https://www.sumatrapdfreader.org/settings.html)**: ShowMenuBar, ReloadModifiedDocuments, CustomScreenDPI
+- new **[advanced settings](https://www.sumatrapdfreader.org/settings.html)**: `ShowMenuBar`, `ReloadModifiedDocuments`, `CustomScreenDPI`
 - left/right clicking no longer changes pages in fullscreen mode (use Presentation mode if you rely on this feature)
 - fixed multiple crashes and made multiple minor improvements
 
 ## 2.4 (2013-10-01)
 
-- full-screen mode for ebooks (Ctrl-L)
+- full-screen mode for ebooks (`Ctrl-L`)
 - new key bindings:
-  - F9 - show/hide menu (not remembered after quitting)
-  - F8 - show/hide toolbar
+  - `F9` - show/hide menu (not remembered after quitting)
+  - `F8` - show/hide toolbar
 - support WebP images (standalone and in comic books)
 - support for RAR5 compressed comic books
 - fixed multiple crashes
@@ -297,8 +297,8 @@ This release no longer supports Windows XP. Latest version that support XP is 3.
 - "Go To Page" in ebook ui
 - add View/Manga Mode menu item for Comic Book (CBZ/CBR) files
 - new key bindings:
-  - Ctrl-Up : page up
-  - Ctrl-Down : page down
+  - `Ctrl-Up` : page up
+  - `Ctrl-Down` : page down
 - add support for OpenXPS documents
 - support Deflate64 in Comic Book (CBZ/CBR) files
 - fixed missing paragraph indentation in EPUB documents
@@ -317,7 +317,7 @@ This release no longer supports Windows XP. Latest version that support XP is 3.
 - add support for FictionBook ebook format
 - add support for PDF documents encrypted with Acrobat X
 - “Print as image” compatibility option in print dialog for documents that fail to print properly
-- new command-line option: -manga-mode [1|true|0|false] for proper display of manga comic books
+- new command-line option: `-manga-mode [1|true|0|false]` for proper display of manga comic books
 - many robustness fixes and small improvements
 
 ## 2.1.1 (2012-05-07)
@@ -336,8 +336,8 @@ This release no longer supports Windows XP. Latest version that support XP is 3.
 
 ## 2.0.1 (2012-04-08)
 
-- fix loading .mobi files from command line
-- fix a crash loading multiple .mobi files at once
+- fix loading `.mobi` files from command line
+- fix a crash loading multiple `.mobi` files at once
 - fix a crash showing tooltips for table of contents tree entries
 
 ## 2.0 (2012-04-02)
@@ -365,8 +365,8 @@ This release no longer supports Windows XP. Latest version that support XP is 3.
 - favorites
 - improved support for right-to-left languages e.g. Arabic
 - logical page numbers are displayed and used, if a document provides them (such as i, ii, iii, etc.)
-- allow to restrict SumatraPDF's features with more granularity; see **[sumatrapdfrestric.init](https://github.com/sumatrapdfreader/sumatrapdf/blob/master/docs/sumatrapdfrestrict.ini)** for documentation
-- -named-dest also matches strings in table of contents
+- allow to restrict SumatraPDF's features with more granularity; see **[sumatrapdfrestrict.ini](https://github.com/sumatrapdfreader/sumatrapdf/blob/master/docs/sumatrapdfrestrict.ini)** for documentation
+- `-named-dest` also matches strings in table of contents
 - improved support for EPS files (requires Ghostscript)
 - more robust installer
 - many minor improvements and bugfixes
@@ -392,7 +392,7 @@ This release no longer supports Windows XP. Latest version that support XP is 3.
 - add support for viewing CBZ and CBR comic books
 - add File/Save Shortcut menu item to create shortcuts to a specific place in a document
 - add context menu for copying text, link addresses and comments. In browser plugin it also adds saving and printing commands
-- add folder browsing (Ctrl+Shift+Right opens next PDF document in the current folder, Ctrl+Shift+Left opens previous document)
+- add folder browsing (`Ctrl + Shift + Right` opens next PDF document in the current folder, `Ctrl + Shift + Left` opens previous document)
 
 ## 1.4 (2011-03-12)
 
@@ -402,16 +402,16 @@ This release no longer supports Windows XP. Latest version that support XP is 3.
 - you can choose a custom installation directory in the installer
 - menu items for re-opening current document in Foxit and PDF-XChange (if they're installed)
 - we no longer compress the installer executable with mpress. It caused some anti-virus programs to falsely report Sumatra as a virus. The downside is that the binaries on disk are now bigger. Note: we still compress the portable .zip version
-- -title cmd-line option was removed
+- `-title` cmd-line option was removed
 - support for AES-256 encrypted PDF documents
 - fixed an integer overflow reported by Jeroen van der Gun and other small fixes and improvements to PDF handling
 
 ## 1.3 (2011-02-04)
 
-- improved text selection and copying. We now mimic the way a browser or Adobe Reader works: just select text with mouse and use Ctrl-C to copy it to a clipboard
-- Shift+Left Mouse now scrolls the document, Ctrl+Left mouse still creates a rectangular selection (for copying images)
-- 'c' shortcut toggles continuous mode
-- '+' / '\*' on the numeric keyboard now do zoom and rotation
+- improved text selection and copying. We now mimic the way a browser or Adobe Reader works: just select text with mouse and use `Ctrl-C` to copy it to a clipboard
+- `Shift + Left Mouse` now scrolls the document, `Ctrl + Left mouse` still creates a rectangular selection (for copying images)
+- `c` shortcut toggles continuous mode
+- `+` / `*` on the numeric keyboard now do zoom and rotation
 - added toolbar icons for Fit Page and Fit Width and updated the look of toolbar icons
 - add support for back/forward mouse buttons for back/forward navigation
 - 1.2 introduces a new full screen mode and made it the default full screen mode. Old mode was still available but not easily discoverable. We've added View/Presentation menu item for new full screen mode and View/Fullscreen menu item for the old full screen mode, to make it more discoverable
@@ -428,8 +428,8 @@ This release no longer supports Windows XP. Latest version that support XP is 3.
 ## 1.2 (2010-11-26)
 
 - improved printing: faster and uses less resources
-- add Ctrl-Y as a shortcut for Custom Zoom
-- add Ctrl-A as a shortcut for Select All Text
+- add `Ctrl-Y` as a shortcut for Custom Zoom
+- add `Ctrl-A` as a shortcut for Select All Text
 - improved full screen mode
 - open embedded PDF documents
 - allow saving PDF document attachments to disk
@@ -444,7 +444,7 @@ This release no longer supports Windows XP. Latest version that support XP is 3.
 - auto-detect commonly used TeX editors for inverse-search command
 - bug fixes to PDF handling (more PDFs are shown correctly)
 - misc bug fixes and small improvements in UI
-- add Ctrl + and Ctrl – as shortcuts for zooming (matches Adobe Reader)
+- add `Ctrl +` and `Ctrl –` as shortcuts for zooming (matches Adobe Reader)
 
 ## 1.0.1 (2009-11-27)
 
@@ -482,26 +482,26 @@ This release no longer supports Windows XP. Latest version that support XP is 3.
 - improvements to DDE (contributed by Danilo Roascio)
 - SyncTex improvements
 - improve persistence of state (contributed by Robert Liu)
-- fix crash when pressing 'Cancel' when entering a password
+- fix crash when pressing `Cancel` when entering a password
 - updated translations
 
 ## 0.9.1 (2008-08-22)
 
 - improved rendering of some PDFs
 - support for links inside PDF file
-- added -restrict and -title cmd-line options (contributed by Matthew Wilcoxson)
+- added `-restrict` and `-title` cmd-line options (contributed by Matthew Wilcoxson)
 - enabled SyncTex support which mistakenly disabled in 0.9
 - misc fixes and translation updates
 
 ## 0.9 (2008-08-10)
 
-- add Ctrl-P as print shortcut
-- add F11 as full-screen shortcut
+- add `Ctrl-P` as print shortcut
+- add `F11` as full-screen shortcut
 - password dialog no longer shows the password
 - support for AES-encrypted PDF files
 - updates to SyncTeX/PdfSync integration (contributed by William Blum)
-- add -nameddest command-line option and DDE commands for jumping to named destination(contributed by Alexander Klenin)
-- add -reuse-instance command-line option (contributed by William Blum)
+- add `-nameddest` command-line option and DDE commands for jumping to named destination (contributed by Alexander Klenin)
+- add `-reuse-instance` command-line option (contributed by William Blum)
 - add DDE command to open PDF file (contributed by William Blum)
 - removed poppler rendering engine resulting in smaller program and updated to latest mupdf sources
 - misc bugfixes and translation updates
@@ -514,8 +514,8 @@ This release no longer supports Windows XP. Latest version that support XP is 3.
 - language change is now a separate dialog instead of a menu
 - remember more settings (like default view)
 - automatic checks for new versions
-- add command-line option -lang $lang
-- add command-line option -print-dialog (contributed by Peter Astrand)
+- add command-line option `-lang $lang`
+- add command-line option `-print-dialog` (contributed by Peter Astrand)
 - ESC or single mouse click hides selection
 - fix showing boxes in table of contents tree
 - translation updates
@@ -530,8 +530,8 @@ This release no longer supports Windows XP. Latest version that support XP is 3.
 - fixed some crashes
 - rendering speedups
 - fixed loading of some PDFs
-- add command-line option -esc-to-exit
-- add command-line option -bgcolor $color
+- add command-line option `-esc-to-exit`
+- add command-line option `-bgcolor $color`
 
 ## 0.7 (2007-07-28)
 
@@ -539,7 +539,7 @@ This release no longer supports Windows XP. Latest version that support XP is 3.
 - made it multi-lingual (13 translations)
 - added Save As option
 - list of recently opened files is updated immediately
-- fixed .pdf extension registration on Vista
+- fixed `.pdf` extension registration on Vista
 - added ability to compile as DLL and C# sample application - contributed by Valery Possoz
 - mingw compilation fixes and project files for CodeBlocks - contributed by MrChuoi
 - fixed a few crashes
@@ -562,8 +562,8 @@ This release no longer supports Windows XP. Latest version that support XP is 3.
 
 - fixed rendering problems with some PDF files
 - speedups - the application should feel snappy and there should be less waiting for rendering
-- added 'r' keybinding for reloading currently open PDF file
-- added <Ctrl>-<Shift>-+ and <Ctrl>-<Shift>-- keybindings to rotate clockwise and counter-clockwise (just like Acrobat Reader)
+- added `r` keybinding for reloading currently open PDF file
+- added `Ctrl-Shift-+` and `Ctrl-Shift--` keybindings to rotate clockwise and counter-clockwise (just like Acrobat Reader)
 - fixed a crash or two
 
 ## 0.4 (2007-02-18)
@@ -576,7 +576,7 @@ This release no longer supports Windows XP. Latest version that support XP is 3.
 - improve the way fonts directory is found
 - improvements to portable mode
 - uninstaller completely removes the program
-- changed name of preferences files from prefs.txt to sumatrapdfprefs.txt
+- changed name of preferences files from `prefs.txt` to `sumatrapdfprefs.txt`
 
 ## 0.3 (2006-11-25)
 


### PR DESCRIPTION
Continuing the [#5394](https://github.com/sumatrapdfreader/sumatrapdf/issues/5394).
So, in the syntax for color values, the opacity value is specified first (I corrected the example, not the explanation).