### PR TITLE
Fix MRU tab switching by always adding current tab to the top of the MRU list

### DIFF
--- a/src/CommandPalette.cpp
+++ b/src/CommandPalette.cpp
@@ -585,16 +585,23 @@ void CommandPaletteWnd::CollectTabsRegular(MainWindow* mainWin, WindowTab* currT
 void CommandPaletteWnd::CollectTabsMru(MainWindow* mainWin, WindowTab* currTab) {
     currTabIdx = 0;
     tabs.Reset();
-    // first add tabs in MRU order from selection history
+    // current tab is by definition the most recently used, so add it first
+    if (currTab) {
+        AppendTab(tabs, currTab, currTab, currTabIdx);
+    }
+    // then add remaining tabs in MRU order from selection history
     Vec<WindowTab*>* history = mainWin->tabSelectionHistory;
     if (history) {
         // history is oldest-first, iterate in reverse for MRU order
         for (int i = history->Size() - 1; i >= 0; i--) {
             WindowTab* tab = history->At(i);
+            if (tab == currTab) {
+                continue;
+            }
             AppendTab(tabs, tab, currTab, currTabIdx);
         }
     }
-    // add any tabs not in the history (e.g. current tab, tabs from other windows)
+    // add any tabs not in the history (e.g. tabs from other windows)
     for (MainWindow* w : gWindows) {
         for (WindowTab* tab : w->Tabs()) {
             bool alreadyAdded = false;


### PR DESCRIPTION
The MRU tab switching is now correct.
Example behavior:
1/ User selects A, then B, C, D
2/ Ctrl-Tab switches from D to C
3/ Ctrl-Tab switches from C to D
4/ Ctrl-Tab,Tab switches from D to B
5/ Ctrl-Tab switches from B to D

Notes:
- MRU tab switching applies to the tabs in the *current* window only (the tabs in the other windows are at the end of the list, in non-MRU order)
- closing a tab does *not* switch to the last tab used (consistent with Firefox MRU behavior)