### PR TITLE
Focus Contents edit field on annotation click

### DIFF
--- a/docs/md/Version-history.md
+++ b/docs/md/Version-history.md
@@ -59,6 +59,7 @@ Available in [pre-release](https://www.sumatrapdfreader.org/prerelease) builds.
 - you can drag&drop images from PDF documents to other applications (web apps, image editors, file explorer etc.)
 - pen/stylus input now works for text selection on Windows tablets
 - fix Edit Annotations window not restoring to the correct monitor in multi-monitor setups
+- focus `Contents` edit field when clicking on an annotation to open or select it in the Edit Annotations window
 - use `GetFileAttributesEx` instead of opening files for change detection on network drives, avoiding Windows Defender re-scans
 - fix toolbar page number misalignment when `PrinterAccess` is revoked in `sumatrapdfrestrict.ini`
 

--- a/src/Canvas.cpp
+++ b/src/Canvas.cpp
@@ -1254,12 +1254,12 @@ static void OnMouseLeftButtonUp(MainWindow* win, int x, int y, WPARAM key) {
     }
 
     if (IsCtrlPressed() && win->annotationUnderCursor) {
-        ShowEditAnnotationsWindow(tab, win->annotationUnderCursor);
+        ShowEditAnnotationsWindow(tab, win->annotationUnderCursor, EditAnnotFocus::Edit);
         return;
     }
 
     if (win->annotationUnderCursor && (tab->selectedAnnotation || tab->editAnnotsWindow)) {
-        SetSelectedAnnotation(tab, win->annotationUnderCursor);
+        SetSelectedAnnotation(tab, win->annotationUnderCursor, false, EditAnnotFocus::Edit);
         return;
     }
 

--- a/src/EditAnnotations.cpp
+++ b/src/EditAnnotations.cpp
@@ -939,7 +939,7 @@ static void UpdateUIForSelectedAnnotation(EditAnnotationsWindow* ew, Annotation*
 
         if (focus == EditAnnotFocus::Edit) {
             HwndSetFocus(ew->editContents->hwnd);
-            ew->editContents->SelectAll();
+            ew->editContents->SetCursorPositionAtEnd();
         } else if (focus == EditAnnotFocus::List) {
             HwndSetFocus(ew->listBox->hwnd);
         } else if (isNew && annot->type == AnnotationType::FreeText) {


### PR DESCRIPTION
## Summary

- Clicking an annotation (Ctrl+click on the page, or click while the Edit Annotations window is already open) now focuses the `Contents` edit field instead of the annotations list, so a note can be typed immediately.
- The cursor is placed at the end of the existing text rather than selecting all, so additional text can be appended without overwriting.

This addresses the same friction described in #5558 / #5559 - minimizing clicks to add a note to an existing highlight (or any annotation).

## Changes

- `src/Canvas.cpp`: pass `EditAnnotFocus::Edit` when click-to-edit opens or refocuses the annotation in the Edit Annotations window.
- `src/EditAnnotations.cpp`: in `EditAnnotFocus::Edit` mode, position cursor at end of contents instead of selecting all.
- `docs/md/Version-history.md`: changelog entry under `next: 3.7`.

## Test plan

- [ ] Open a PDF with no Edit Annotations window open. Ctrl+click on a highlight -> window opens, `Contents` field is focused, cursor at end of any existing text.
- [ ] With the Edit Annotations window already open, click on a different highlight in the page -> that annotation is selected in the list, focus moves to `Contents`, cursor at end.
- [ ] Selecting an entry in the annotations list (rather than clicking on the page) keeps focus in the list - unchanged behavior.
- [ ] Creating a new annotation via `CmdCreateAnnot*` with `focusedit=true` still focuses `Contents` - unchanged behavior (cursor at end is irrelevant for empty content).