### PR TITLE
Add support for saving and loading workspace sessions

### DIFF
--- a/src/Commands.cpp
+++ b/src/Commands.cpp
@@ -237,6 +237,8 @@ static SeqStrings gCommandNames =
     "CmdSetScreenshotHotkey\0"
     "CmdToggleReuseInstance\0"
     "CmdToggleChmUI\0"
+    "CmdSaveWorkspace\0"
+    "CmdOpenWorkspace\0"
     "CmdNone\0"
     "\0";
 
@@ -464,6 +466,8 @@ static i32 gCommandIds[] = {
     CmdSetScreenshotHotkey,
     CmdToggleReuseInstance,
     CmdToggleChmUI,
+    CmdSaveWorkspace,
+    CmdOpenWorkspace,
     CmdNone,
 };
 
@@ -691,6 +695,8 @@ SeqStrings gCommandDescriptions =
     "Set Screenshot Hotkey\0"
     "Toggle Reuse Instance\0"
     "Toggle CHM UI\0"
+    "Save Workspace...\0"
+    "Open Workspace...\0"
     "Do nothing\0"
     "\0";
 // clang-format on

--- a/src/Commands.h
+++ b/src/Commands.h
@@ -232,7 +232,9 @@ enum {
     CmdSetScreenshotHotkey = 421,
     CmdToggleReuseInstance = 422,
     CmdToggleChmUI = 423,
-    CmdNone = 424,
+    CmdSaveWorkspace = 424,
+    CmdOpenWorkspace = 425,
+    CmdNone = 426,
 
     /* range for file history */
     CmdFileHistoryFirst,

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -120,6 +120,14 @@ static MenuDef menuDefFile[] = {
         CmdSaveAs,
     },
     {
+        _TRN("Save &Workspace..."),
+        CmdSaveWorkspace,
+    },
+    {
+        _TRN("Open Workspace..."),
+        CmdOpenWorkspace,
+    },
+    {
         _TRN("Save Annotations to existing PDF"),
         CmdSaveAnnotations,
     },

--- a/src/SumatraPDF.cpp
+++ b/src/SumatraPDF.cpp
@@ -4048,6 +4048,147 @@ static TempWStr GetFileFilterTemp() {
     return ToWStrTemp(fileFilter);
 }
 
+// Writes the current session's open file paths to the given file.
+// Returns true on success.
+static bool DoSaveWorkspaceToFile(MainWindow* win, const char* path) {
+    // Persist display state into FileStates and rebuild SessionData so we
+    // have a fresh, authoritative list of every currently-open tab.
+    SaveSettings();
+
+    StrBuilder sb;
+    Vec<SessionData*>* sessionData = gGlobalPrefs->sessionData;
+    for (SessionData* sd : *sessionData) {
+        for (TabState* ts : *sd->tabStates) {
+            if (str::IsEmpty(ts->filePath)) {
+                continue;
+            }
+            sb.Append(ts->filePath);
+            sb.Append("\r\n");
+        }
+    }
+
+    ByteSlice data = sb.AsByteSlice();
+    bool ok = file::WriteFile(path, data);
+    if (!ok) {
+        MessageBoxWarning(win->hwndFrame, _TRA("Failed to save workspace"));
+    }
+    return ok;
+}
+
+static void SaveWorkspace(MainWindow* win) {
+    if (!CanAccessDisk()) {
+        return;
+    }
+
+    OPENFILENAMEW ofn{};
+    ofn.lStructSize = sizeof(ofn);
+    ofn.hwndOwner = win->hwndFrame;
+    ofn.lpstrFilter = L"SumatraPDF Workspace (*.sumatraws)\0*.sumatraws\0All Files (*.*)\0*.*\0";
+    ofn.nFilterIndex = 1;
+    ofn.Flags = OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST | OFN_HIDEREADONLY;
+    ofn.lpstrDefExt = L"sumatraws";
+
+    WCHAR dstFileName[MAX_PATH]{};
+    ofn.lpstrFile = dstFileName;
+    ofn.nMaxFile = MAX_PATH;
+
+    if (!GetSaveFileNameW(&ofn)) {
+        return;
+    }
+
+    TempStr path = ToUtf8Temp(dstFileName);
+    DoSaveWorkspaceToFile(win, path);
+}
+
+static void LoadWorkspace(MainWindow* win) {
+    if (!CanAccessDisk()) {
+        return;
+    }
+
+    // Show the Open dialog first so the user can cancel before being asked
+    // about saving.
+    OPENFILENAMEW ofn{};
+    ofn.lStructSize = sizeof(ofn);
+    ofn.hwndOwner = win->hwndFrame;
+    ofn.lpstrFilter = L"SumatraPDF Workspace (*.sumatraws)\0*.sumatraws\0All Files (*.*)\0*.*\0";
+    ofn.nFilterIndex = 1;
+    ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_HIDEREADONLY;
+
+    WCHAR srcFileName[MAX_PATH]{};
+    ofn.lpstrFile = srcFileName;
+    ofn.nMaxFile = MAX_PATH;
+
+    if (!GetOpenFileNameW(&ofn)) {
+        return;
+    }
+
+    // Ask whether the current workspace should be saved before replacing it.
+    {
+        UINT flags = MB_YESNOCANCEL | MB_ICONQUESTION | MbRtlReadingMaybe();
+        auto caption = _TRA("Save Workspace");
+        auto msg = _TRA("Do you want to save the current workspace before opening a new one?");
+        int res = MsgBox(win->hwndFrame, msg, caption, flags);
+        if (res == IDCANCEL) {
+            return;
+        }
+        if (res == IDYES) {
+            // Show Save As dialog; if the user cancels it we abort the whole
+            // load so we don't unexpectedly discard the current session.
+            OPENFILENAMEW saveOfn{};
+            saveOfn.lStructSize = sizeof(saveOfn);
+            saveOfn.hwndOwner = win->hwndFrame;
+            saveOfn.lpstrFilter = L"SumatraPDF Workspace (*.sumatraws)\0*.sumatraws\0All Files (*.*)\0*.*\0";
+            saveOfn.nFilterIndex = 1;
+            saveOfn.Flags = OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST | OFN_HIDEREADONLY;
+            saveOfn.lpstrDefExt = L"sumatraws";
+
+            WCHAR saveFileName[MAX_PATH]{};
+            saveOfn.lpstrFile = saveFileName;
+            saveOfn.nMaxFile = MAX_PATH;
+
+            if (!GetSaveFileNameW(&saveOfn)) {
+                return;
+            }
+            TempStr savePath = ToUtf8Temp(saveFileName);
+            if (!DoSaveWorkspaceToFile(win, savePath)) {
+                return;
+            }
+        }
+    }
+
+    // Close all open tabs across every window before loading the new workspace
+    // so that only the files from the loaded workspace remain open.
+    Vec<MainWindow*> allWindows(gWindows);
+    for (MainWindow* w : allWindows) {
+        CloseAllTabs(w);
+    }
+
+    // Read and open the files listed in the workspace file.
+    TempStr path = ToUtf8Temp(srcFileName);
+    ByteSlice data = file::ReadFile(path);
+    if (data.empty()) {
+        return;
+    }
+
+    // Parse one file path per line; look up the matching FileState from
+    // history so that scroll position, zoom etc. are restored as well.
+    StrVec lines;
+    TempStr content = str::DupTemp((char*)data.data(), (int)data.size());
+    Split(&lines, content, "\n", true);
+    str::Free(data.data());
+
+    // Use the first still-valid window as the load target.
+    MainWindow* loadWin = gWindows.size() > 0 ? gWindows.at(0) : win;
+    for (char* line : lines) {
+        str::TrimWSInPlace(line, str::TrimOpt::Both);
+        if (str::Leni(line) == 0) {
+            continue;
+        }
+        LoadArgs args(line, loadWin);
+        LoadDocument(&args);
+    }
+}
+
 static void OpenFile(MainWindow* win) {
     if (!CanAccessDisk()) {
         return;
@@ -6489,6 +6630,14 @@ static LRESULT FrameOnCommand(MainWindow* win, HWND hwnd, UINT msg, WPARAM wp, L
 
         case CmdSaveAs:
             SaveCurrentFileAs(win);
+            break;
+
+        case CmdSaveWorkspace:
+            SaveWorkspace(win);
+            break;
+
+        case CmdOpenWorkspace:
+            LoadWorkspace(win);
             break;
 
         case CmdPrint:


### PR DESCRIPTION
Implemented two new commands, `CmdSaveWorkspace` and `CmdOpenWorkspace`, to enable saving and loading of workspace sessions.

- Updated `Commands.cpp` to include the new commands in `gCommandNames`, `gCommandIds`, and `gCommandDescriptions`.
- Modified `Commands.h` to assign unique IDs to the new commands and adjusted `CmdNone`.
- Added menu items for "Save Workspace..." and "Open Workspace..." in `Menu.cpp`.
- Implemented `DoSaveWorkspaceToFile` in `SumatraPDF.cpp` to handle saving open file paths to a workspace file.
- Added `SaveWorkspace` to display a "Save As" dialog and save the current session.
- Added `LoadWorkspace` to load a workspace file, prompting the user to save the current session and closing all open tabs before loading.
- Updated `FrameOnCommand` to handle the new commands and invoke the respective functions.

These changes enhance session management by allowing users to persist and restore their workspace state.
