### PR TITLE
fix file history order number displaying 0 instead of 10

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1225,8 +1225,8 @@ static void AddFileMenuItem(HMENU menuFile, const char* filePath, int index) {
     menuString = ShortenStringUtf8InTheMiddleTemp(menuString, kMaxRunes);
 
     TempStr fileName = MenuToSafeStringTemp(menuString);
-    int menuIdx = (int)((index + 1) % 10);
-    menuString = str::FormatTemp("&%d) %s", menuIdx, fileName);
+    int menuIdx = (int)((index) % kFileHistoryMaxRecent);
+    menuString = str::FormatTemp("&%d) %s", menuIdx + 1, fileName);
     uint menuId = CmdFileHistoryFirst + index;
     uint flags = MF_BYCOMMAND | MF_ENABLED | MF_STRING;
     InsertMenuW(menuFile, CmdExit, flags, menuId, ToWStrTemp(menuString));


### PR DESCRIPTION
Once 10 files have been opened, the file history menu displays the oldest item as number 0 instead of number 10.
This is caused by some arithmetic involving +1 and modulus.

For this fix to work, the loop bound in function `AppendRecentFilesToMenu` and the modulus operand in function `AddFileMenuItem` must have the same value (they already did, I just made it explicit by replacing a "magic value" with the constant `kFileHistoryMaxRecent`). Otherwise the menu numbers may "wrap around".


<img width="717" height="594" alt="ordinal-bug" src="https://github.com/user-attachments/assets/c2e87a8c-a738-4af3-b0c6-c73afb76324d" />
