### PR TITLE
Fix: Place start menu shortcuts under "Programs" Shell folder instead of root

### DIFF
--- a/src/Installer.cpp
+++ b/src/Installer.cpp
@@ -200,10 +200,11 @@ static bool CreateAppShortcut(int csidl, const char* installedExePath) {
 // https://docs.microsoft.com/en-us/windows/win32/shell/csidl
 // CSIDL_COMMON_DESKTOPDIRECTORY - files and folders on desktop for all users. C:\Documents and Settings\All
 // Users\Desktop
-// CSIDL_COMMON_STARTMENU - Start menu for all users, C:\Documents and Settings\All Users\Start Menu
+// CSIDL_COMMON_PROGRAMS - Programs item in Start menu for all users, C:\Documents and Settings\All Users\Start
+// Menu\Programs
 // CSIDL_DESKTOP - virtual folder, desktop for current user
-// CSIDL_STARTMENU - Start menu for current user. Settings\username\Start Menu
-static int shortcutDirs[] = {CSIDL_COMMON_DESKTOPDIRECTORY, CSIDL_COMMON_STARTMENU, CSIDL_DESKTOP, CSIDL_STARTMENU};
+// CSIDL_PROGRAMS - Programs item in Start menu for current user. Settings\username\Start Menu\Programs
+static int shortcutDirs[] = {CSIDL_COMMON_DESKTOPDIRECTORY, CSIDL_COMMON_PROGRAMS, CSIDL_DESKTOP, CSIDL_PROGRAMS};
 
 static void CreateAppShortcuts(bool forAllUsers, const char* installedExePath) {
     logf("CreateAppShortcuts(forAllUsers=%d)\n", (int)forAllUsers);


### PR DESCRIPTION
### Description
This PR fixes an issue where the installer incorrectly creates start menu shortcuts directly in the current user's (or all users') Start Menu root directory, rather than inside the standard "Programs" Shell folder. 

In `src/Installer.cpp`, the shortcut directory array previously contained `CSIDL_COMMON_STARTMENU` and `CSIDL_STARTMENU`. This has been updated to use `CSIDL_COMMON_PROGRAMS` and `CSIDL_PROGRAMS` to ensure shortcuts are placed neatly within the appropriate subfolder, aligning with Windows user experience standards.

### Changes Made
* **`src/Installer.cpp`**: 
  * Replaced `CSIDL_STARTMENU` with `CSIDL_PROGRAMS` for current user shortcuts.
  * Replaced `CSIDL_COMMON_STARTMENU` with `CSIDL_COMMON_PROGRAMS` for all users shortcuts.
  * Updated outdated code comments to match the new variables.

### Verification
* Verified that shortcuts are now correctly created under `...\Start Menu\Programs` instead of cluttering the root Start Menu directory during installation.

<img width="989" height="272" alt="CSIDL_STARTMENU" src="https://github.com/user-attachments/assets/2bbe2250-f63b-435b-bab8-88839d79b7e5" />