### PR TITLE
Fix two heap-buffer-overflows in vendored libheif 1.21.2 (backport upstream v1.22.0 fixes)

### DIFF
--- a/ext/libheif/libheif/image-items/mask_image.cc
+++ b/ext/libheif/libheif/image-items/mask_image.cc
@@ -113,8 +113,8 @@ Error MaskImageCodec::decode_mask_image(const HeifContext* context,
 
   size_t stride;
   uint8_t* dst = img->get_plane(heif_channel_Y, &stride);
-  if (((uint32_t)stride) == width) {
-    memcpy(dst, data.data(), data.size());
+  if (stride == static_cast<size_t>(width)) {
+    memcpy(dst, data.data(), static_cast<size_t>(width) * height);
   }
   else
   {

--- a/ext/libheif/libheif/pixelimage.cc
+++ b/ext/libheif/libheif/pixelimage.cc
@@ -951,13 +951,16 @@ Error HeifPixelImage::copy_image_to(const std::shared_ptr<const HeifPixelImage>&
     uint32_t src_width = source->get_width(channel);
     uint32_t src_height = source->get_height(channel);
 
-    uint32_t copy_width = std::min(src_width, channel_width(w - x0, chroma, channel));
-    uint32_t copy_height = std::min(src_height, channel_height(h - y0, chroma, channel));
-
-    copy_width *= source->get_storage_bits_per_pixel(channel) / 8;
-
     uint32_t xs = channel_width(x0, chroma, channel);
     uint32_t ys = channel_height(y0, chroma, channel);
+
+    // Compute copy size from actual plane bounds to avoid chroma rounding mismatch.
+    // channel_height(y0) + channel_height(h - y0) can exceed channel_height(h) with 4:2:0
+    // due to ceiling division, so we use (plane_size - offset) instead.
+    uint32_t copy_width = std::min(src_width, channel_width(w, chroma, channel) - xs);
+    uint32_t copy_height = std::min(src_height, channel_height(h, chroma, channel) - ys);
+
+    copy_width *= source->get_storage_bits_per_pixel(channel) / 8;
     xs *= source->get_storage_bits_per_pixel(channel) / 8;
 
     for (uint32_t py = 0; py < copy_height; py++) {
@@ -1854,13 +1857,16 @@ HeifPixelImage::extract_image_area(uint32_t x0, uint32_t y0, uint32_t w, uint32_
       };
     }
 
-    uint32_t copy_width = channel_width(minW, chroma, channel);
-    uint32_t copy_height = channel_height(minH, chroma, channel);
-
-    copy_width *= get_storage_bits_per_pixel(channel) / 8;
-
     uint32_t xs = channel_width(x0, chroma, channel);
     uint32_t ys = channel_height(y0, chroma, channel);
+
+    // Clamp copy size to source plane bounds to avoid chroma rounding mismatch OOB read.
+    uint32_t src_plane_h = channel_height(get_height(), chroma, channel);
+    uint32_t src_plane_w = channel_width(get_width(), chroma, channel);
+    uint32_t copy_width = std::min(channel_width(minW, chroma, channel), src_plane_w - xs);
+    uint32_t copy_height = std::min(channel_height(minH, chroma, channel), src_plane_h - ys);
+
+    copy_width *= get_storage_bits_per_pixel(channel) / 8;
     xs *= get_storage_bits_per_pixel(channel) / 8;
 
     for (uint32_t py = 0; py < copy_height; py++) {


### PR DESCRIPTION
## Summary

`ext/libheif` vendors libheif **1.21.2**, which contains two heap-buffer-overflow (write) bugs in the HEIC/HEIF decode path. Both are reachable from `src/utils/AvifReader.cpp` (`heif_context_read_from_memory_without_copy` -> `heif_context_get_primary_image_handle` -> `heif_decode_image`), i.e. simply opening a crafted `.heic`/`.heif` file triggers them.

This PR backports the corresponding upstream fixes, released in libheif **v1.22.0**, applied unchanged to the vendored sources.

## Root causes

**1) `decode_mask_image()` — `ext/libheif/libheif/image-items/mask_image.cc`**
The `stride == width` fast path does `memcpy(dst, data.data(), data.size())`, copying the entire mask payload into a `width * height` plane. A mask item whose data is larger than `width * height` overflows the destination heap allocation.
Upstream fix copies exactly `width * height` bytes.
ASan (vendored 1.21.2): `WRITE` heap-buffer-overflow in `MaskImageCodec::decode_mask_image` at `mask_image.cc:117` (memcpy), 0 bytes past a `width*height` plane.

**2) `copy_image_to()` — `ext/libheif/libheif/pixelimage.cc`**
For grid images with 4:2:0 chroma and odd tile dimensions, the per-tile copy extent is computed as `channel_height(h - y0, ...)`. Because chroma dimensions use ceiling division, `channel_height(y0) + channel_height(h - y0)` can exceed `channel_height(h)`, so pasting the bottom tile row writes one chroma row past the destination plane. The same rounding issue exists in `extract_image_area()`.
Upstream fix derives the copy extent from the actual plane bounds (`plane_size - offset`).
ASan (vendored 1.21.2): `WRITE` heap-buffer-overflow in `HeifPixelImage::copy_image_to` at `pixelimage.cc:964` (memcpy).

## Upstream references

- mask_image: strukturag/libheif@123694271ac02f2de68a3ccdc5d483eb8a2ae593
- pixelimage (copy_image_to + extract_image_area): strukturag/libheif@23903961e1237ecdb0779a65b423cb75f524d254

Both are contained in libheif v1.22.0. The diff here is byte-for-byte equivalent to those two upstream commits (`mask_image.cc`: 2 changed lines; `pixelimage.cc`: 2 hunks).

## Verification

Built the vendored `ext/libheif` sources (1.21.2, identical to the files in this tree) with AddressSanitizer + libde265, before and after this patch, and exercised the decode path used by `AvifReader.cpp`:

| Input | Before (1.21.2) | After (this PR) |
|---|---|---|
| mask PoC | heap-buffer-overflow WRITE @ `mask_image.cc:117` | decoded OK, no ASan report |
| 4:2:0 odd-tile grid PoC | heap-buffer-overflow WRITE @ `pixelimage.cc:964` | decoded OK, no ASan report |
| normal HEIC (regression) | decoded OK | decoded OK |

(SumatraPDF's overall build is premake/Windows; verification was done at the libheif library level, which is where the vulnerable code and the fix live.)

## Disclosure

Both issues were reported privately via e-mail per `SECURITY.md` before this PR. This PR only backports the already-public upstream fixes.
