### PR TITLE
Clean up Start Menu root shortcuts from 3.4–3.6 installers

### DIFF
--- a/src/Installer.cpp
+++ b/src/Installer.cpp
@@ -228,11 +228,17 @@ static void RemoveShortcutFile(int csidl) {
 // those are shortcuts created by versions before 3.4
 static int shortcutDirsPre34[] = {CSIDL_COMMON_PROGRAMS, CSIDL_PROGRAMS, CSIDL_DESKTOP};
 
+// those are shortcuts created by versions 3.4 through 3.6
+static int shortcutDirs34To36[] = {CSIDL_COMMON_DESKTOPDIRECTORY, CSIDL_COMMON_STARTMENU, CSIDL_DESKTOP, CSIDL_STARTMENU};
+
 void RemoveAppShortcuts() {
     for (int csidl : shortcutDirs) {
         RemoveShortcutFile(csidl);
     }
     for (int csidl : shortcutDirsPre34) {
+        RemoveShortcutFile(csidl);
+    }
+    for (int csidl : shortcutDirs34To36) {
         RemoveShortcutFile(csidl);
     }
 }


### PR DESCRIPTION
This fixes a cleanup regression after #5658.

PR #5658 moved newly created Start Menu shortcuts from `CSIDL_COMMON_STARTMENU` / `CSIDL_STARTMENU` to `CSIDL_COMMON_PROGRAMS` / `CSIDL_PROGRAMS`.

However, versions 3.4 through 3.6 created shortcuts in the Start Menu root folder. `RemoveAppShortcuts()` no longer checks `CSIDL_COMMON_STARTMENU` / `CSIDL_STARTMENU`, so those old shortcuts are not removed during upgrade. They also remain after uninstalling the newer version.

Repro:
1. Install SumatraPDF 3.4–3.6.
2. Upgrade to a build containing #5658.
3. The old Start Menu root shortcut remains.
4. Uninstall the newer version.
5. The old Start Menu root shortcut still remains.

This PR adds the legacy 3.4–3.6 shortcut locations to the removal pass, following the same approach that was added in 9ba639ceb7c0693ac0145012dd97f81995ee430e for pre-3.4 shortcuts.
