### PR TITLE
Fix RefHover popup region on mupdf per-glyph ink boxes

### DIFF
--- a/src/RefHover.cpp
+++ b/src/RefHover.cpp
@@ -858,11 +858,22 @@ void RefHoverOnTimer(RefHoverState* s, HWND hwndCanvas, EngineBase* engine, floa
         int textLen = 0;
         Rect* coords = nullptr;
         const WCHAR* text = engine->GetTextForPage(destPage, &textLen, &coords);
+        // mupdf's per-glyph ink boxes have varying tops within a line; the
+        // detectors key off coords[i].y as a line coordinate, so flatten each
+        // line to a uniform top-aligned row first (see NormalizeGlyphLines).
+        Rect* normCoords = coords;
+        if (coords && textLen > 0) {
+            normCoords = AllocArray<Rect>((size_t)textLen);
+            NormalizeGlyphLines(coords, normCoords, textLen);
+        }
         // Equation cross-reference: tight box around the labelled line.
         // Falls through to DetectEntryBox when no eq label is found.
-        region = DetectEquationBox(text, coords, textLen, mediabox, destX, destY);
+        region = DetectEquationBox(text, normCoords, textLen, mediabox, destX, destY);
         if (region.dx <= 0.f || region.dy <= 0.f) {
-            region = DetectEntryBox(text, coords, textLen, mediabox, destX, destY);
+            region = DetectEntryBox(text, normCoords, textLen, mediabox, destX, destY);
+        }
+        if (normCoords != coords) {
+            free(normCoords);
         }
     }
     // New destination — reset user-driven zoom. baseZoom matches the

--- a/src/RefHoverDetect.cpp
+++ b/src/RefHoverDetect.cpp
@@ -153,6 +153,75 @@ static void ClipToMediabox(RectF& box, RectF mediabox) {
     }
 }
 
+// Snap glyphs to text lines and rewrite each glyph's y/dy to its line's
+// top/height. mupdf returns tight per-glyph ink boxes, so glyphs on one
+// visual line have *different* tops (a period or comma sits well below a
+// capital, an ascender above it). Every line heuristic below treats
+// coords[i].y as the line's position (grouping by y±tol), which a stray
+// low-topped glyph from an adjacent line defeats — e.g. the trailing "."
+// of the previous bibliography entry landing inside the destination band and
+// hijacking the entry-start search. The glyph *baseline* (y + dy) is stable
+// across a line (a digit and a period share it), so cluster by baseline and
+// flatten each line to a uniform top-aligned row — the shape the detectors
+// assume. `out` must have room for textLen rects; aliasing `coords` is not
+// allowed.
+void NormalizeGlyphLines(const Rect* coords, Rect* out, int textLen) {
+    if (!coords || !out || textLen <= 0) {
+        return;
+    }
+    constexpr int kBaselineTolPt = 4;
+    constexpr int kMaxLines = 4096;
+    int* lineBaseline = AllocArray<int>(kMaxLines);
+    int* lineTop = AllocArray<int>(kMaxLines);
+    int* lineBottom = AllocArray<int>(kMaxLines);
+    int* lineId = AllocArray<int>((size_t)textLen);
+    int nLines = 0;
+    for (int i = 0; i < textLen; i++) {
+        int bl = coords[i].y + coords[i].dy;
+        int best = -1;
+        int bestDist = kBaselineTolPt + 1;
+        for (int L = 0; L < nLines; L++) {
+            int dist = bl - lineBaseline[L];
+            if (dist < 0) {
+                dist = -dist;
+            }
+            if (dist < bestDist) {
+                bestDist = dist;
+                best = L;
+            }
+        }
+        if (best < 0) {
+            // new line (or, on the unlikely line overflow, fold into line 0)
+            if (nLines < kMaxLines) {
+                best = nLines++;
+                lineBaseline[best] = bl;
+                lineTop[best] = coords[i].y;
+                lineBottom[best] = bl;
+            } else {
+                best = 0;
+            }
+        } else {
+            if (coords[i].y < lineTop[best]) {
+                lineTop[best] = coords[i].y;
+            }
+            if (bl > lineBottom[best]) {
+                lineBottom[best] = bl;
+            }
+        }
+        lineId[i] = best;
+    }
+    for (int i = 0; i < textLen; i++) {
+        out[i] = coords[i];
+        int L = lineId[i];
+        out[i].y = lineTop[L];
+        out[i].dy = lineBottom[L] - lineTop[L];
+    }
+    free(lineBaseline);
+    free(lineTop);
+    free(lineBottom);
+    free(lineId);
+}
+
 // Used when the link doesn't resolve to a recognizable bibliography entry —
 // TOC targets, topbar/section links, table or figure captions, image-only
 // PDFs. Returns a region that spans the full page width and goes from the
@@ -617,6 +686,48 @@ RectF DetectEntryBox(const WCHAR* text, const Rect* coords, int textLen, RectF m
         firstLineDy = 12;
     }
 
+    // Hanging-indent bracket entry: biblatex sizes the label column for the
+    // widest label, so a narrow label ("[TA05]") is separated from its body
+    // by a labelsep gap wider than LineRunExtent's within-line gap threshold.
+    // The label-anchored run above then stops at the label, collapsing
+    // lineRunRightX (and columnRightX) to the label width — that clips the
+    // body horizontally and lets the box latch onto neighbouring labels.
+    // Bridge the single labelsep gap: find the first glyph on the first line
+    // right of the label run and extend a fresh run from there. The body run
+    // is dense and stops at a real column gutter, so this stays 2-column-safe;
+    // the bridge itself is capped at kMaxLabelSepPt, well under a gutter, so
+    // it can't jump into an adjacent column.
+    if (text[startIdx] == L'[') {
+        constexpr int kMaxLabelSepPt = 50;
+        int bandBot = firstLineY + (firstLineDy > 10 ? firstLineDy : 10);
+        int bodyIdx = -1;
+        int bodyX = INT_MAX;
+        for (int i = 0; i < textLen; i++) {
+            WCHAR c = text[i];
+            if (c == L' ' || c == L'\t' || c == L'\n' || c == L'\r') {
+                continue;
+            }
+            Rect r = coords[i];
+            if (r.y < firstLineY - 3 || r.y > bandBot) {
+                continue;
+            }
+            if (r.x <= lineRunRightX + 3 || r.x > lineRunRightX + kMaxLabelSepPt) {
+                continue;
+            }
+            if (r.x < bodyX) {
+                bodyX = r.x;
+                bodyIdx = i;
+            }
+        }
+        if (bodyIdx >= 0) {
+            int bLeftIdx, bLeftX, bRightX;
+            LineRunExtent(text, coords, textLen, bodyIdx, &bLeftIdx, &bLeftX, &bRightX);
+            if (bRightX + 40 > columnRightX) {
+                columnRightX = bRightX + 40;
+            }
+        }
+    }
+
     // Bracket-style entry ("[ZM12]", "[1]", …): build the bounding box from
     // a y-range whose upper bound is the next "[" at firstLineLeftX. The
     // iterative scan below depends on text-array order, but some PDFs draw
@@ -659,6 +770,53 @@ RectF DetectEntryBox(const WCHAR* text, const Rect* coords, int textLen, RectF m
         // first line — whose glyph tops can round to within 1–2 pt of the
         // "[" we picked — is reliably excluded.
         entryYBoundary -= 6;
+        // Trailing-gap trim: a last-on-page entry has no sibling "[" below to
+        // bound it, so entryYBoundary runs to the kMaxBracketEntryPt cap and
+        // the box would swallow the page footer / page number (or a long
+        // blank margin). Walk the entry's lines down from the first line and
+        // stop at the first vertical gap wider than ~1.5 line heights — that
+        // gap separates the entry from the footer. Inter-entry leading in a
+        // dense bibliography is far smaller, so a real next entry (bounded by
+        // its "[" above) is never trimmed: blockBottom keeps growing past
+        // entryYBoundary and the trim is a no-op.
+        {
+            int lineH = firstLineDy > 0 ? firstLineDy : 12;
+            int gapThresh = lineH * 3 / 2;
+            if (gapThresh < 15) {
+                gapThresh = 15;
+            }
+            int prevBottom = firstLineY + firstLineDy;
+            int blockBottom = prevBottom;
+            for (;;) {
+                int nextBottom = -1;
+                for (int i = 0; i < textLen; i++) {
+                    WCHAR c = text[i];
+                    if (c == L' ' || c == L'\t' || c == L'\n' || c == L'\r') {
+                        continue;
+                    }
+                    Rect r = coords[i];
+                    if (r.x < firstLineLeftX - 20 || r.x > columnRightX) {
+                        continue;
+                    }
+                    // a glyph on a line strictly below the current block but
+                    // within one gap of it (line tops cluster near the top y)
+                    if (r.y <= prevBottom - 2 || r.y > prevBottom + gapThresh) {
+                        continue;
+                    }
+                    if (r.y + r.dy > nextBottom) {
+                        nextBottom = r.y + r.dy;
+                    }
+                }
+                if (nextBottom < 0) {
+                    break;
+                }
+                blockBottom = nextBottom;
+                prevBottom = nextBottom;
+            }
+            if (blockBottom + 1 < entryYBoundary) {
+                entryYBoundary = blockBottom + 1;
+            }
+        }
         int bMinX = INT_MAX, bMinY = INT_MAX, bMaxX = INT_MIN, bMaxY = INT_MIN;
         for (int i = 0; i < textLen; i++) {
             WCHAR c = text[i];

--- a/src/RefHoverDetect.h
+++ b/src/RefHoverDetect.h
@@ -15,6 +15,14 @@
 //
 // Returned RectF is in PDF user space, clipped to mediabox.
 
+// Flatten per-glyph ink boxes to uniform top-aligned line rows. mupdf reports
+// tight per-glyph boxes whose tops vary within a line; the detectors below key
+// off coords[i].y as a line coordinate, so callers must pass coords through
+// this first (grouping by baseline = y+dy). `out` needs textLen rects and must
+// not alias `coords`. Synthetic top-aligned input is left effectively
+// unchanged (each line already has a single top).
+void NormalizeGlyphLines(const Rect* coords, Rect* out, int textLen);
+
 // Landscape view: full page width strip anchored at destY, extending downward
 // to the last text glyph or a recognised caption block. Fallback when no
 // recognisable entry or equation is found.

--- a/src/utils/tests/RefHover_ut.cpp
+++ b/src/utils/tests/RefHover_ut.cpp
@@ -361,8 +361,152 @@ static void LandscapeBoxBasicShape() {
     utassert(box.y + box.dy <= kPageH);
 }
 
+// (3g) Hanging-indent bracket bibliography with a narrow label ("[TA05]"):
+// biblatex sizes the label column for the widest label, so a narrow label is
+// separated from its body by a labelsep gap wider than the within-line gap
+// threshold. The detected box must still span the full body width (the body
+// is bridged), not collapse to the label width and clip the entry.
+static void HangingIndentNarrowLabelFullWidth() {
+    WCHAR text[1024];
+    Rect coords[1024];
+    int len = 0;
+    // Narrow label "[TA05]" ends at x=72+6*6=108; body starts at x=130 — a
+    // 22pt labelsep gap, wider than LineRunExtent's 20pt within-line gap.
+    AddText(text, coords, len, 1024, L"[TA05]", 72, 200);
+    AddText(text, coords, len, 1024, L"J. Tyree and A. Akerman. Architecture decisions.", 130, 200);
+    AddText(text, coords, len, 1024, L"continuation line two of the same entry.", 130, 215);
+    AddText(text, coords, len, 1024, L"[Vai20]", 72, 240);
+    AddText(text, coords, len, 1024, L"Thomas Vaillant. Log4brains. 2020.", 130, 240);
+    RectF box = DetectEntryBox(text, coords, len, Mediabox(), 72.f, 200.f);
+    utassert(!IsEmpty(box));
+    // box must reach across the body (without the labelsep bridge it would
+    // collapse to ~the label width, near x=150)
+    utassert(box.x + box.dx >= 300.f);
+    // still bounded to the first entry
+    utassert(box.y + box.dy < 240.f);
+    utassert(box.x <= 72.f + 6.f);
+}
+
+// (3h) 2-column layout where the left-column entry has a wide labelsep gap:
+// the body bridge must reach the body without jumping the (much wider) column
+// gutter into the right column.
+static void TwoColumnHangingIndentStaysInColumn() {
+    WCHAR text[1024];
+    Rect coords[1024];
+    int len = 0;
+    // Left column: narrow label at x=72 (ends ~108), body at x=130 (22pt
+    // labelsep), body line ends ~246.
+    AddText(text, coords, len, 1024, L"[TA05]", 72, 200);
+    AddText(text, coords, len, 1024, L"Smith J. 2010. Some title.", 130, 200);
+    AddText(text, coords, len, 1024, L"continuation of the entry.", 130, 215);
+    AddText(text, coords, len, 1024, L"[Vai20]", 72, 240);
+    // Right column body at x=340 (gutter ~286..340), same y range. The body
+    // bridge (capped at 50pt) cannot reach x=340 from the label run, and the
+    // dense left-column body run stops at the gutter.
+    for (int i = 0; i < 4; i++) {
+        AddText(text, coords, len, 1024, L"right column body text line..", 340, 200 + i * 15);
+    }
+    RectF box = DetectEntryBox(text, coords, len, Mediabox(), 72.f, 200.f);
+    utassert(!IsEmpty(box));
+    // box must not reach into the right column at x=340
+    utassert(box.x + box.dx < 340.f);
+    utassert(box.y + box.dy < 240.f);
+}
+
+// (3i) Last entry on a bibliography page (no sibling "[" below) followed by a
+// page-number footer far below: the trailing-gap trim ends the box at the
+// entry's last line, not at the footer.
+static void LastEntryTrailingFooterTrimmed() {
+    WCHAR text[1024];
+    Rect coords[1024];
+    int len = 0;
+    AddText(text, coords, len, 1024, L"[Zim25]", 72, 600);
+    AddText(text, coords, len, 1024, L"Olaf Zimmermann. ADG: A Light Tool.", 130, 600);
+    AddText(text, coords, len, 1024, L"continuation of the last entry.", 130, 615);
+    // page-number footer far below (73pt gap), centered in the text column
+    AddText(text, coords, len, 1024, L"13", 300, 700);
+    RectF box = DetectEntryBox(text, coords, len, Mediabox(), 72.f, 600.f);
+    utassert(!IsEmpty(box));
+    // footer at y=700 must be excluded (box ends just below the 2nd line)
+    utassert(box.y + box.dy < 650.f);
+}
+
+// (12) NormalizeGlyphLines flattens a line whose glyphs have varying tops
+// (mupdf's tight ink boxes) to a single top-aligned row, keyed by baseline,
+// while keeping distinct lines separate.
+static void NormalizeGlyphLinesFlattensLine() {
+    // Line 1 at baseline 110: a tall glyph (top 100, h 10) and a low one
+    // (a period: top 105, h 5) — same baseline. Line 2 at baseline 130.
+    Rect in[3] = {Rect{72, 100, 6, 10}, Rect{78, 105, 4, 5}, Rect{72, 120, 6, 10}};
+    Rect out[3];
+    NormalizeGlyphLines(in, out, 3);
+    // line 1 glyphs flattened to the same top (100) and height (110-100=10)
+    utassert(out[0].y == 100 && out[0].dy == 10);
+    utassert(out[1].y == 100 && out[1].dy == 10);
+    // line 2 stays distinct
+    utassert(out[2].y == 120 && out[2].dy == 10);
+}
+
+// (13) mupdf-style variable glyph tops: the previous entry's trailing line
+// ends with a period whose tight ink box top sits below the digits on the
+// same line and inside the destination band. Without baseline normalization
+// that period hijacks the entry-start search (narrow strip / wrong entry);
+// after NormalizeGlyphLines the detector locks onto the real "[Buc+23]" entry.
+static void VariableGlyphTopsEntryNotHijacked() {
+    WCHAR text[1024];
+    Rect coords[1024];
+    int len = 0;
+    // Previous entry's trailing line "1622292." at baseline 313: digits top
+    // 305 (h 8), final period top 310 (h 3) — same baseline, body column x.
+    const WCHAR* tail = L"1622292";
+    for (int i = 0; tail[i]; i++) {
+        text[len] = tail[i];
+        coords[len] = Rect{130 + i * 6, 305, 6, 8};
+        len++;
+    }
+    text[len] = L'.';
+    coords[len] = Rect{130 + 7 * 6, 310, 4, 3};
+    len++;
+    // Entry "[Buc+23]" label (x=72) + body (x=130) at baseline ~327 (top 316).
+    const WCHAR* label = L"[Buc+23]";
+    for (int i = 0; label[i]; i++) {
+        text[len] = label[i];
+        coords[len] = Rect{72 + i * 6, 316, 6, 11};
+        len++;
+    }
+    const WCHAR* body = L"Georg Buchgeher et al. Using ADRs in Open Source.";
+    for (int i = 0; body[i]; i++) {
+        text[len] = body[i];
+        coords[len] = Rect{130 + i * 6, 316, 6, 9};
+        len++;
+    }
+    // Next entry "[JB05]" below at top 352.
+    const WCHAR* nb = L"[JB05] A. Jansen and J. Bosch.";
+    for (int i = 0; nb[i]; i++) {
+        text[len] = nb[i];
+        coords[len] = Rect{72 + i * 6, 352, 6, 10};
+        len++;
+    }
+    Rect norm[1024];
+    NormalizeGlyphLines(coords, norm, len);
+    RectF box = DetectEntryBox(text, norm, len, Mediabox(), 72.f, 312.f);
+    utassert(!IsEmpty(box));
+    // entry start, not the previous line (normalized top 305)
+    utassert(box.y > 305.f);
+    // label included and full body width captured (not a narrow strip)
+    utassert(box.x <= 72.f + 6.f);
+    utassert(box.x + box.dx >= 300.f);
+    // ends before the next entry
+    utassert(box.y + box.dy < 352.f);
+}
+
 void RefHoverTest() {
     AccentedAllCapsHeadingDetected();
+    HangingIndentNarrowLabelFullWidth();
+    TwoColumnHangingIndentStaysInColumn();
+    LastEntryTrailingFooterTrimmed();
+    NormalizeGlyphLinesFlattensLine();
+    VariableGlyphTopsEntryNotHijacked();
     AuthorYearEntryFitsToOneEntry();
     BodyTextParenRejected();
     BracketEntryFitsToOneEntry();


### PR DESCRIPTION
## Problem

The citation/reference hover popup (`RefHover`) cropped to the wrong region on many real PDFs: a clipped narrow strip, or a full-page landscape fallback showing several entries, instead of the single target bibliography entry.

Root cause: the region detectors in `RefHoverDetect.cpp` key off `coords[i].y` as a *line* coordinate, assuming glyphs on one line share a top. `EngineBase::GetTextForPage` returns mupdf's **tight per-glyph ink boxes**, whose tops vary within a line (a period/comma sits well below a capital; ascenders and brackets higher). So the trailing `.` of the previous bibliography entry could fall into the destination band and hijack the entry-start glyph.

(This only reproduces against the real engine — `PyMuPDF`/`fitz` rawdict reports near-uniform tops and hides it.)

## Fix

- **`NormalizeGlyphLines`**: cluster glyphs by *baseline* (`y + dy`, which is stable across a line) and flatten each line to a uniform top-aligned row before detection. `RefHoverOnTimer` normalizes the page coords once and passes them to both `DetectEquationBox` and `DetectEntryBox`.
- **`DetectEntryBox` bracket path** — derive `columnRightX` from the body run, bridging the hanging-indent labelsep gap (capped so it can't jump a column gutter). A narrow biblatex label (`[TA05]`) no longer collapses the box width and clips the entry.
- **`DetectEntryBox` bracket path** — trailing-gap trim so a last-on-page entry (no sibling `[` below it) ends at its last line instead of swallowing the page-number footer.

## Testing

- `RefHover_ut`: added coverage for baseline normalization, the variable-top entry-start hijack, narrow-label full width, 2-column safety, and the footer trim. `test_util` passes all unit tests.
- Verified against the real engine on two biblatex PDFs (single- and multi-page bibliographies): every citation link now yields a correct full-width single-entry popup region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)