### PR TITLE
RefHover: plain wheel scrolls main doc; Shift+wheel scrolls popup

### DIFF
--- a/src/Canvas.cpp
+++ b/src/Canvas.cpp
@@ -380,7 +380,8 @@ static void StartImageDragDrop(MainWindow* win) {
 }
 
 // Resize handle positions that used in resizing annotations
-enum class ResizeHandle {
+enum class ResizeHandle
+{
     None = 0,
     TopLeft,
     Top,
@@ -2248,22 +2249,28 @@ static LRESULT CanvasOnMouseWheel(MainWindow* win, UINT msg, WPARAM wp, LPARAM l
     // Mouse-wheel on the citation-hover popup (cursor still on the citation
     // link that opened it). Avoids moving the cursor onto the popup itself,
     // which would dismiss the hover.
-    //   plain wheel → scroll popup content (rolls over to prev/next page)
+    //   shift+wheel → scroll popup content (rolls over to prev/next page)
     //   ctrl+wheel  → zoom popup content
+    //   plain wheel → falls through to scroll the main document, as if the
+    //                 popup weren't there (modifier-less wheel scrolling a
+    //                 document shouldn't get hijacked by the hover popup)
     if (win->refHover && win->refHover->hwndPopup && IsWindowVisible(win->refHover->hwndPopup)) {
-        DisplayModel* dmHover = win->AsFixed();
-        if (dmHover) {
-            Point pt = HwndGetCursorPos(win->hwndCanvas);
-            IPageElement* elHover = dmHover->GetElementAtPos(pt, nullptr);
-            if (IsInternalLinkDest(elHover, dmHover)) {
-                short delta = GET_WHEEL_DELTA_WPARAM(wp);
-                bool isCtrl = (LOWORD(wp) & MK_CONTROL) || IsCtrlPressed();
-                if (isCtrl) {
-                    RefHoverWheelZoom(win->refHover, dmHover->GetEngine(), delta);
-                } else {
-                    RefHoverWheelScroll(win->refHover, dmHover->GetEngine(), delta);
+        bool isCtrl = (LOWORD(wp) & MK_CONTROL) || IsCtrlPressed();
+        bool isShift = (LOWORD(wp) & MK_SHIFT) || IsShiftPressed();
+        if (isCtrl || isShift) {
+            DisplayModel* dmHover = win->AsFixed();
+            if (dmHover) {
+                Point pt = HwndGetCursorPos(win->hwndCanvas);
+                IPageElement* elHover = dmHover->GetElementAtPos(pt, nullptr);
+                if (IsInternalLinkDest(elHover, dmHover)) {
+                    short delta = GET_WHEEL_DELTA_WPARAM(wp);
+                    if (isCtrl) {
+                        RefHoverWheelZoom(win->refHover, dmHover->GetEngine(), delta);
+                    } else {
+                        RefHoverWheelScroll(win->refHover, dmHover->GetEngine(), delta);
+                    }
+                    return 0;
                 }
-                return 0;
             }
         }
     }

--- a/src/RefHover.cpp
+++ b/src/RefHover.cpp
@@ -36,9 +36,10 @@
 //       positions each render their own content (no stale popup on the
 //       second hover).
 //   [ ] Popup hides on mouse-out, re-appears on re-enter.
-//   [ ] Mouse-wheel over popup scrolls; rolls over to the prev / next page
-//       when the viewport reaches a page edge.
+//   [ ] Shift+mouse-wheel over popup scrolls; rolls over to the prev / next
+//       page when the viewport reaches a page edge.
 //   [ ] Ctrl+mouse-wheel over popup zooms in / out.
+//   [ ] Plain mouse-wheel scrolls the main document (popup not hijacking it).
 //   [ ] Popup height grows on bigger monitors (capped at ~90% of work
 //       area, max 1400px).
 //


### PR DESCRIPTION
Previously plain mouse-wheel over the citation-hover popup zoomed/scrolled the popup, which was surprising while scrolling through a document. Now plain wheel falls through to scroll the main document as if the popup weren't there; Shift+wheel scrolls the popup, Ctrl+wheel zooms it.

See https://github.com/sumatrapdfreader/sumatrapdf/discussions/5671#discussioncomment-17407515