### PR TITLE
Find: clamp Page Up/Down in results list instead of wrapping (#5742)

### DIFF
--- a/docs/md/Version-history.md
+++ b/docs/md/Version-history.md
@@ -18,6 +18,7 @@ Available in [pre-release](https://www.sumatrapdfreader.org/prerelease) builds.
 - can convert an image to a PDF: right-click an image (or an open image document) and choose `Image / Convert to PDF`, or pick `PDF` in the format drop-down of the Save Image dialog. The new PDF gets `CreationDate`/`ModDate` metadata with the current time and time zone (fixes #949)
 - in the Favorites pane and menu, a favorite for a file with a long name now shows your favorite's name first, then the file name, so the name you gave it is no longer pushed out of view (fixes #829, #2236)
 - case-insensitive search now treats German ß as equivalent to `ss`, so searching `Strasse` finds `Straße` and vice versa (fixes #933)
+- in the floating search window's results list, `Page Up` / `Page Down` now move the selection a page toward the first / last match and stop there, instead of wrapping around to a seemingly random earlier / later match (fixes #5742)
 - hovering a thumbnail on the Frequently Read home page now shows a ✕ button in its top-right corner to remove that document from the list, without going through the right-click menu (fixes #283)
 - new zoom mode `Fit by Orientation` (in the View / Zoom menu) that automatically fits width when the view is landscape and fits page when portrait, updating as you resize the window or rotate the screen (fixes #702)
 - add `sumatrapdf-tool.exe` command-line tools for PDF manipulation (see [Tools](Tools.md))

--- a/src/FindWindow.cpp
+++ b/src/FindWindow.cpp
@@ -493,25 +493,11 @@ bool FindWindowWnd::MoveResultSelection(WPARAM vkey) {
         case VK_UP:
             idx = (cur < 0) ? n - 1 : (cur - 1 + n) % n;
             break;
-        case VK_NEXT: // Page Down
-            if (cur < 0) {
-                idx = 0;
-            } else {
-                idx = cur + kPage;
-                if (idx >= n) {
-                    idx %= n;
-                }
-            }
+        case VK_NEXT: // Page Down: jump a page forward, clamp at the last match (#5742)
+            idx = (cur < 0) ? 0 : std::min(cur + kPage, n - 1);
             break;
-        case VK_PRIOR: // Page Up
-            if (cur < 0) {
-                idx = n - 1;
-            } else {
-                idx = cur - kPage;
-                if (idx < 0) {
-                    idx = (idx % n + n) % n;
-                }
-            }
+        case VK_PRIOR: // Page Up: jump a page back, clamp at the first match (#5742)
+            idx = (cur < 0) ? n - 1 : std::max(cur - kPage, 0);
             break;
         default:
             return false;


### PR DESCRIPTION
Fixes #5742.

### Root cause

In the floating search window's results list, `FindWindowWnd::MoveResultSelection`
(`src/FindWindow.cpp`) moves the selection on `Page Up` / `Page Down` by a fixed
`kPage = 10` matches, then on overshoot **wraps around via modulo** (`idx %= n`).

Because the jump is large (not ±1), the wrapped landing point usually falls on the
*wrong side* of where you started. With 13 matches, pressing **Page Down** from match 8
lands on match 5 — i.e. it moves the selection **backward**. `Page Up` is the mirror
image (moves forward). That's the "feels like hitting the random button" the reporter
described:

| start | current `Page Down` | this PR `Page Down` |
|------:|--------------------:|--------------------:|
| 8 / 13 | 5 (jumps **backward**) | 12 (last match) |
| 3 / 13 | 0 (jumps backward) | 12 |

### Fix

Clamp the page jump to the ends instead of wrapping:

- `Page Down` → `min(cur + kPage, n - 1)` (advance a page, stop at the last match)
- `Page Up`   → `max(cur - kPage, 0)` (go back a page, stop at the first match)

Single-step arrow keys (`Up`/`Down`) and `Find Next`/`Prev` keep their intentional
one-at-a-time wrap (last↔first, issue #5692) — only the large page jump is changed.

### Testing

Developed on macOS (no local Windows build). The change is pure index arithmetic, so I
verified it with a standalone test enumerating both the old (wrap) and new (clamp) math
across all start positions: the old code moves the selection the wrong direction in 10 of
13 cases, while the clamped version is monotonic and always in range (`Page Down` never
moves backward, `Page Up` never forward). Build is covered by CI; would appreciate a
maintainer confirming the feel in-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)