### PR TITLE
Don't materialize cloud placeholder files for thumbnails (fixes #5756)

### DIFF
--- a/src/SumatraPDF.cpp
+++ b/src/SumatraPDF.cpp
@@ -841,6 +841,14 @@ static bool ShouldSaveThumbnail(FileState* ds) {
         return false;
     }
 
+    // don't materialize (hydrate) a cloud-only placeholder file just to make a
+    // thumbnail. opening it would force a slow, possibly multi-minute download
+    // (e.g. OneDrive "Files On-Demand" dehydrated file). issue #5756
+    if (path::IsCloudPlaceholder(ds->filePath)) {
+        logf("ShouldSaveThumbnail: skipping cloud placeholder '%s'\n", ds->filePath);
+        return false;
+    }
+
     // don't create thumbnails for files that won't need them anytime soon
     Vec<FileState*> list;
     if (gGlobalPrefs->homePageSortByFrequentlyRead) {


### PR DESCRIPTION
TL;DR: Use `Path::IsCloudPlaceholder` for Thumbnails to filter.

## Problem

Opening a OneDrive "Files On-Demand" *dehydrated* (cloud-only placeholder) file to render a home-page thumbnail forced a full hydration — Windows/OneDrive downloads the whole file. For large files on slow links this hangs the UI for minutes (#5756).

## Fix

Gate thumbnail creation in `ShouldSaveThumbnail()` on `path::IsCloudPlaceholder()` (the helper added in 7d918e8b9 but not yet wired up). If the file's bytes aren't local yet, skip making a thumbnail.

This is the single gate for both thumbnail call sites (file open + reload), so no `CreateEngineFromFile` runs and no hydration is triggered.

## Why the normal case still works

When the user actually opens the file, the open hydrates it → `IsCloudPlaceholder()` returns false → the thumbnail is created on that pass. The guard only fires when the file is genuinely cloud-only, which is exactly the behavior requested in the issue ("if a file is projected and not materialized, it should not materialize for the preview").

`IsCloudPlaceholder()` checks `FILE_ATTRIBUTE_OFFLINE | RECALL_ON_OPEN | RECALL_ON_DATA_ACCESS` via `GetFileAttributesW` — metadata only, no hydration.

Built clean (dbg64), 0 warnings / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)