### PR TITLE
RefHover: fix watermarked 2-column pages and wrapped numeric citations

### DIFF
--- a/src/RefHoverDetect.cpp
+++ b/src/RefHoverDetect.cpp
@@ -221,6 +221,109 @@ void NormalizeGlyphLines(const Rect* coords, Rect* out, int glyphCount) {
     free(lineId);
 }
 
+// Drop diagonal draft / "under review" watermark glyphs from a page's *raw*
+// glyph arrays before any box detection. A watermark stamp is set far larger
+// than body text and, being rotated, sits roughly one glyph per baseline —
+// each on a sparse row — whereas a heading or title is a horizontal run of
+// same-baseline glyphs. Removing it up front keeps a 2-column gutter empty and
+// the entry bounds tight, instead of special-casing oversized glyphs in every
+// scan. Run this on the engine's raw coords *before* NormalizeGlyphLines:
+// normalization clusters by baseline (±4pt) and could fold a watermark glyph
+// into a body line, hiding its true height.
+//
+// `outText`/`outCoords` are caller-allocated with room for glyphCount entries;
+// returns the number of glyphs kept (written to the front of the out arrays).
+int StripWatermarkGlyphs(WStr text, const Rect* coords, WCHAR* outText, Rect* outCoords) {
+    int n = text.len;
+    if (n <= 0 || !coords || !outText || !outCoords) {
+        return 0;
+    }
+    // Typical body glyph height = the most common dy (the watermark, a heading,
+    // and any super/subscripts are all minorities). Histogram over non-space
+    // glyph heights and take the mode.
+    int maxDy = 0;
+    for (int i = 0; i < n; i++) {
+        if (coords[i].dy > maxDy) {
+            maxDy = coords[i].dy;
+        }
+    }
+    int modeDy = 0;
+    if (maxDy > 0) {
+        int* hist = AllocArray<int>((size_t)maxDy + 1);
+        for (int i = 0; i < n; i++) {
+            WCHAR c = text.s[i];
+            if (c == L' ' || c == L'\t' || c == L'\n' || c == L'\r') {
+                continue;
+            }
+            int d = coords[i].dy;
+            if (d > 0) {
+                hist[d]++;
+            }
+        }
+        int modeCount = 0;
+        for (int d = 1; d <= maxDy; d++) {
+            if (hist[d] > modeCount) {
+                modeCount = hist[d];
+                modeDy = d;
+            }
+        }
+        free(hist);
+    }
+
+    // Only strip when there's a stable body height to compare against, and only
+    // glyphs clearly taller than it (1.5x) — well above tall "[" labels / caps.
+    constexpr int kMinBodyDy = 4;
+    bool canStrip = modeDy >= kMinBodyDy;
+    int hgtThresh = modeDy + modeDy / 2; // 1.5 * modeDy
+    constexpr int kBaselineTolPt = 4;
+    constexpr int kMinRowGlyphs = 3; // a real text row has at least this many
+
+    int outLen = 0;
+    for (int i = 0; i < n; i++) {
+        WCHAR c = text.s[i];
+        bool isSpace = (c == L' ' || c == L'\t' || c == L'\n' || c == L'\r');
+        bool drop = false;
+        if (canStrip && !isSpace && coords[i].dy > hgtThresh) {
+            // Sparse-row test: count non-space glyphs sharing this glyph's
+            // baseline (y+dy, stable across a visual line) AND of comparable
+            // height. A rotated watermark glyph stands nearly alone on its
+            // baseline; a heading is a dense row of same-size glyphs. Requiring
+            // *similar height* also catches a watermark glyph whose baseline
+            // happens to coincide with a body line — it's then the lone tall
+            // glyph on a row of small body text, not one of a tall row.
+            int bl = coords[i].y + coords[i].dy;
+            int hi = coords[i].dy;
+            int rowGlyphs = 0;
+            for (int j = 0; j < n; j++) {
+                WCHAR cj = text.s[j];
+                if (cj == L' ' || cj == L'\t' || cj == L'\n' || cj == L'\r') {
+                    continue;
+                }
+                if (abs((coords[j].y + coords[j].dy) - bl) > kBaselineTolPt) {
+                    continue;
+                }
+                if (abs(coords[j].dy - hi) * 2 > hi) { // height differs by > 50%
+                    continue;
+                }
+                rowGlyphs++;
+                if (rowGlyphs >= kMinRowGlyphs) {
+                    break;
+                }
+            }
+            if (rowGlyphs < kMinRowGlyphs) {
+                drop = true;
+            }
+        }
+        if (drop) {
+            continue;
+        }
+        outText[outLen] = c;
+        outCoords[outLen] = coords[i];
+        outLen++;
+    }
+    return outLen;
+}
+
 // Used when the link doesn't resolve to a recognizable bibliography entry —
 // TOC targets, topbar/section links, table or figure captions, image-only
 // PDFs. Returns a region that spans the full page width and goes from the

--- a/src/RefHoverDetect.h
+++ b/src/RefHoverDetect.h
@@ -23,6 +23,13 @@
 // unchanged (each line already has a single top).
 void NormalizeGlyphLines(const Rect* coords, Rect* out, int glyphCount);
 
+// Remove diagonal draft / "under review" watermark glyphs (oversized + sitting
+// on sparse baselines) from a page's raw glyph arrays, so 2-column gutter and
+// entry-bound detection see clean text. Run on the engine's raw coords *before*
+// NormalizeGlyphLines. `outText`/`outCoords` need room for glyphCount entries;
+// returns the kept-glyph count, written to the front of the out arrays.
+int StripWatermarkGlyphs(WStr text, const Rect* coords, WCHAR* outText, Rect* outCoords);
+
 // Landscape view: full page width strip anchored at destY, extending downward
 // to the last text glyph or a recognised caption block. Fallback when no
 // recognisable entry or equation is found.

--- a/src/RefHoverShow.cpp
+++ b/src/RefHoverShow.cpp
@@ -56,10 +56,19 @@ void RefHoverOnTimer(RefHoverState* s, HWND hwndCanvas, EngineBase* engine, floa
     } else {
         Rect* coords = nullptr;
         WStr text = engine->GetTextForPage(destPage, nullptr, &coords);
+        WCHAR* cleanText = nullptr;
+        Rect* cleanCoords = nullptr;
         Rect* normCoords = coords;
         if (coords && !wstr::IsEmpty(text)) {
-            normCoords = AllocArray<Rect>((size_t)text.len);
-            NormalizeGlyphLines(coords, normCoords, text.len);
+            // Strip the page watermark on the raw glyphs first (its true height
+            // is only visible pre-normalization), then normalize the survivors
+            // so the detectors below see clean, baseline-flattened text.
+            cleanText = AllocArray<WCHAR>((size_t)text.len);
+            cleanCoords = AllocArray<Rect>((size_t)text.len);
+            int cleanLen = StripWatermarkGlyphs(text, coords, cleanText, cleanCoords);
+            text = WStr(cleanText, cleanLen);
+            normCoords = AllocArray<Rect>((size_t)cleanLen);
+            NormalizeGlyphLines(cleanCoords, normCoords, cleanLen);
         }
         region = DetectEquationBox(text, normCoords, mediabox, destX, destY);
         if (region.dx <= 0.f || region.dy <= 0.f) {
@@ -68,6 +77,8 @@ void RefHoverOnTimer(RefHoverState* s, HWND hwndCanvas, EngineBase* engine, floa
         if (normCoords != coords) {
             free(normCoords);
         }
+        free(cleanText);
+        free(cleanCoords);
     }
     s->displayed.userZoom = 1.f;
     float baseZoom = useLinkZoom ? linkZoom : ((pageZoom > 0.f) ? pageZoom : kRefHoverRenderZoom);

--- a/src/RefHoverTextDetect.cpp
+++ b/src/RefHoverTextDetect.cpp
@@ -508,75 +508,211 @@ bool DetectNumericCitationInPageText(WStr text, const Rect* coords, int textLen,
         return false;
     }
 
-    // 2. The cursor must sit inside a "[ ... ]" bracket on its own line. Walk
-    // left to '[' and right to ']', staying on the cursor's text line and
-    // allowing only the chars that make up a numeric citation list
-    // ("[1]", "[1, 2]", "[3-5]").
     int cursorY = coords[cursorIdx].y;
     int lineTol = coords[cursorIdx].dy + 4;
     if (lineTol < 12) {
         lineTol = 14;
     }
-    auto sameLine = [&](int i) { return abs(coords[i].y - cursorY) <= lineTol; };
-    auto isListChar = [](WCHAR c) { return iswdigit(c) || c == L' ' || c == L'\t' || c == L',' || c == L'-'; };
+    // A numeric citation list may wrap across a line break ("[8, 17,\n18]"), so
+    // the "[ ... ]" walk must span a couple of lines. It can't walk by array
+    // index, though: some PDFs emit a wrapped number far from its '[' in the
+    // glyph stream (observed: the glyph before "43]" sat 196pt above, not at
+    // the "[42," one line up). So reconstruct *local reading order* — gather
+    // glyphs in a vertical band around the cursor and order them
+    // top-to-bottom / left-to-right — then walk that. "[42," (end of one line)
+    // then sits immediately before "43]" (start of the next), while the
+    // out-of-order stream neighbour falls outside the band.
+    // Digits, separators, and dash forms used in page ranges. Beyond the ASCII
+    // hyphen, accept the Unicode figure/en/em dash and minus sign, since
+    // typeset ranges ("9–14") use an en-dash, not '-'.
+    auto isListChar = [](WCHAR c) {
+        return iswdigit(c) || c == L' ' || c == L'\t' || c == L',' || c == L'-' || c == L'\x2012' ||
+               c == L'\x2013' || c == L'\x2014' || c == L'\x2212';
+    };
 
-    int open = -1;
-    for (int i = cursorIdx; i >= 0 && sameLine(i); i--) {
-        WCHAR c = text.s[i];
-        if (c == L'[') {
-            open = i;
-            break;
+    int blTol = (lineTol / 2 > 3) ? lineTol / 2 : 3;
+    int cursorBL = coords[cursorIdx].y + coords[cursorIdx].dy;
+    int cursorX = coords[cursorIdx].x;
+
+    // Build one text line's column-limited segment: glyph indices whose baseline
+    // (y+dy, stable across a line) is within blTol of targetBL, sorted
+    // left-to-right, then restricted to the contiguous x-run (splits at gaps
+    // wider than a column gutter) that overlaps [refLo, refHi]. This keeps the
+    // neighbouring column — and the diagonal watermark, whose glyphs sit on
+    // their own scattered baselines — out of the segment. A whole-Y-band
+    // reconstruction can't: it merges both columns into one logical line and
+    // buries a wrapped citation's "[" behind the other column's text.
+    constexpr int kColGap = 16;
+    auto buildSegment = [&](int targetBL, int refLo, int refHi, int* out, int cap, int* segLo, int* segHi) -> int {
+        int cnt = 0;
+        for (int i = 0; i < textLen && cnt < cap; i++) {
+            if (abs((coords[i].y + coords[i].dy) - targetBL) <= blTol) {
+                out[cnt++] = i;
+            }
         }
-        // Tolerate the cursor landing on the closing ']' itself.
-        if (c == L']' && i == cursorIdx) {
-            continue;
+        for (int a = 1; a < cnt; a++) { // insertion sort by x
+            int v = out[a];
+            int vx = coords[v].x;
+            int b = a - 1;
+            while (b >= 0 && coords[out[b]].x > vx) {
+                out[b + 1] = out[b];
+                b--;
+            }
+            out[b + 1] = v;
         }
-        if (!isListChar(c)) {
-            break;
+        int chosenS = -1, chosenE = -1;
+        int s = 0;
+        while (s < cnt) {
+            int e = s;
+            while (e + 1 < cnt) {
+                int gap = coords[out[e + 1]].x - (coords[out[e]].x + coords[out[e]].dx);
+                if (gap > kColGap) {
+                    break;
+                }
+                e++;
+            }
+            int runLo = coords[out[s]].x;
+            int runHi = coords[out[e]].x + coords[out[e]].dx;
+            if (runHi >= refLo && runLo <= refHi) {
+                chosenS = s;
+                chosenE = e;
+                break;
+            }
+            s = e + 1;
         }
-    }
-    if (open < 0) {
+        if (chosenS < 0) {
+            *segLo = 0;
+            *segHi = -1;
+            return 0;
+        }
+        int n = chosenE - chosenS + 1;
+        for (int t = 0; t < n; t++) {
+            out[t] = out[chosenS + t];
+        }
+        *segLo = coords[out[0]].x;
+        *segHi = coords[out[n - 1]].x + coords[out[n - 1]].dx;
+        return n;
+    };
+
+    constexpr int kSegCap = 512;
+    int curSeg[kSegCap];
+    int curLo = 0, curHi = -1;
+    int curN = buildSegment(cursorBL, cursorX, cursorX, curSeg, kSegCap, &curLo, &curHi);
+    if (curN <= 0) {
         return false;
     }
-    int close = -1;
-    for (int i = open + 1; i < textLen && sameLine(i); i++) {
-        WCHAR c = text.s[i];
+    // Nearest text line above / below in the same column (a glyph overlapping
+    // the cursor line's x-range), so a wrapped citation's other half is
+    // reachable without pulling in the neighbouring column.
+    int prevBL = INT_MIN, nextBL = INT_MAX;
+    for (int i = 0; i < textLen; i++) {
+        int gx = coords[i].x;
+        int gxr = gx + coords[i].dx;
+        if (gxr < curLo - kColGap || gx > curHi + kColGap) {
+            continue;
+        }
+        int bl = coords[i].y + coords[i].dy;
+        if (bl < cursorBL - blTol && bl > prevBL) {
+            prevBL = bl;
+        }
+        if (bl > cursorBL + blTol && bl < nextBL) {
+            nextBL = bl;
+        }
+    }
+    int prevSeg[kSegCap];
+    int nextSeg[kSegCap];
+    int pLo, pHi, nLo, nHi;
+    int prevN = (prevBL != INT_MIN) ? buildSegment(prevBL, curLo, curHi, prevSeg, kSegCap, &pLo, &pHi) : 0;
+    int nextN = (nextBL != INT_MAX) ? buildSegment(nextBL, curLo, curHi, nextSeg, kSegCap, &nLo, &nHi) : 0;
+
+    // Reading order: previous line, cursor line, next line — each sorted by x.
+    int m = prevN + curN + nextN;
+    int* seq = AllocArray<int>((size_t)m);
+    {
+        int w = 0;
+        for (int t = 0; t < prevN; t++) {
+            seq[w++] = prevSeg[t];
+        }
+        for (int t = 0; t < curN; t++) {
+            seq[w++] = curSeg[t];
+        }
+        for (int t = 0; t < nextN; t++) {
+            seq[w++] = nextSeg[t];
+        }
+    }
+    auto cleanup = [&]() { free(seq); };
+    int cursorPos = -1;
+    for (int k = 0; k < m; k++) {
+        if (seq[k] == cursorIdx) {
+            cursorPos = k;
+            break;
+        }
+    }
+    if (cursorPos < 0) {
+        cleanup();
+        return false;
+    }
+
+    // 2. Walk the reconstructed order left to '[' and right to ']', through
+    // citation-list chars only (a letter ends the walk, bounding it).
+    int openPos = -1;
+    for (int k = cursorPos; k >= 0; k--) {
+        WCHAR c = text.s[seq[k]];
+        if (c == L'[') {
+            openPos = k;
+            break;
+        }
+        if (c == L']' && k == cursorPos) {
+            continue; // cursor landed on the closing ']'
+        }
+        if (!isListChar(c)) {
+            break;
+        }
+    }
+    if (openPos < 0) {
+        cleanup();
+        return false;
+    }
+    int closePos = -1;
+    for (int k = openPos + 1; k < m; k++) {
+        WCHAR c = text.s[seq[k]];
         if (c == L']') {
-            close = i;
+            closePos = k;
             break;
         }
         if (!isListChar(c)) {
             break;
         }
     }
-    if (close <= open + 1) {
+    if (closePos <= openPos + 1) {
+        cleanup();
         return false;
     }
 
     // 3. Pick the number token nearest the cursor inside the brackets.
     int bestNum = 0;
     int bestTokDist = INT_MAX;
-    int i = open + 1;
-    while (i < close) {
-        if (!iswdigit(text.s[i])) {
-            i++;
+    int k = openPos + 1;
+    while (k < closePos) {
+        if (!iswdigit(text.s[seq[k]])) {
+            k++;
             continue;
         }
-        int start = i;
+        int start = k;
         int val = 0;
-        while (i < close && iswdigit(text.s[i])) {
-            val = val * 10 + (text.s[i] - L'0');
+        while (k < closePos && iswdigit(text.s[seq[k]])) {
+            val = val * 10 + (text.s[seq[k]] - L'0');
             if (val > 99999) {
                 val = 99999; // guard against pathological runs
             }
-            i++;
+            k++;
         }
-        int end = i - 1;
+        int end = k - 1;
         int dist;
-        if (cursorIdx < start) {
-            dist = start - cursorIdx;
-        } else if (cursorIdx > end) {
-            dist = cursorIdx - end;
+        if (cursorPos < start) {
+            dist = start - cursorPos;
+        } else if (cursorPos > end) {
+            dist = cursorPos - end;
         } else {
             dist = 0;
         }
@@ -586,12 +722,34 @@ bool DetectNumericCitationInPageText(WStr text, const Rect* coords, int textLen,
         }
     }
     if (bestNum <= 0) {
+        cleanup();
         return false;
     }
     if (srcRectOut) {
-        // stable per-occurrence key: the "[N]" bracket span on this line
-        *srcRectOut = GlyphSpanBounds(coords, textLen, open, close);
+        // stable per-occurrence key: bounds of the "[ ... ]" span (may cover
+        // two lines when the list wraps).
+        int xMin = INT_MAX, sMinY = INT_MAX, xMax = INT_MIN, sMaxY = INT_MIN;
+        for (int p = openPos; p <= closePos; p++) {
+            Rect r = coords[seq[p]];
+            if (r.dx <= 0 && r.dy <= 0) {
+                continue;
+            }
+            if (r.x < xMin) {
+                xMin = r.x;
+            }
+            if (r.y < sMinY) {
+                sMinY = r.y;
+            }
+            if (r.x + r.dx > xMax) {
+                xMax = r.x + r.dx;
+            }
+            if (r.y + r.dy > sMaxY) {
+                sMaxY = r.y + r.dy;
+            }
+        }
+        *srcRectOut = (xMin != INT_MAX) ? Rect{xMin, sMinY, xMax - xMin, sMaxY - sMinY} : Rect{};
     }
+    cleanup();
     *numOut = bestNum;
     return true;
 }

--- a/src/base/tests/RefHover_ut.cpp
+++ b/src/base/tests/RefHover_ut.cpp
@@ -479,6 +479,159 @@ static void NumericCitationSrcRectDistinctOnLine() {
     utassert(first.x != second.x);
 }
 
+// (13c) Numeric citation page range written with an en-dash ("[2, 9–14]"):
+// the en-dash must not break bracket detection, and hovering an endpoint
+// resolves to that endpoint's number.
+static void NumericCitationRangeEnDash() {
+    WCHAR text[256];
+    Rect coords[256];
+    int len = 0;
+    // "deploy [2, 9–14]." — en-dash split from "14" so the \x2013 escape does
+    // not swallow the following hex digits.
+    AddText(text, coords, len, 256, L"deploy [2, 9\x2013" L"14].", 72, 200);
+    int num = 0;
+    // Cursor on the '9' (idx 11 → x = 72 + 11*6 = 138).
+    bool ok = DetectNumericCitationInPageText(WStr(text, len), coords, len, Point{141, 206}, &num);
+    utassert(ok);
+    utassert(num == 9);
+    // Cursor on the '4' of "14" (idx 14 → x = 72 + 14*6 = 156).
+    num = 0;
+    ok = DetectNumericCitationInPageText(WStr(text, len), coords, len, Point{159, 206}, &num);
+    utassert(ok);
+    utassert(num == 14);
+}
+
+// (13d) Numeric citation list that wraps across a line break ("[8, 17,\n18]"):
+// bracket detection must span the line break. Hovering a number on either the
+// first or the second line resolves to that number. The 2nd line sits 20pt
+// below (> the 16pt single-line tolerance) so this exercises the multi-line
+// walk, not the within-line tolerance.
+static void NumericCitationLineBreakList() {
+    WCHAR text[256];
+    Rect coords[256];
+    int len = 0;
+    AddText(text, coords, len, 256, L"in AECO [8, 17,", 72, 200); // '[' at idx 8 (x=120)
+    AddText(text, coords, len, 256, L"18]. These", 72, 220);       // '1' at idx 15 (x=72,y=220)
+    int num = 0;
+    // Cursor on the '8' on line 1 (idx 9 → x = 72 + 9*6 = 126).
+    bool ok = DetectNumericCitationInPageText(WStr(text, len), coords, len, Point{129, 206}, &num);
+    utassert(ok);
+    utassert(num == 8);
+    // Cursor on the wrapped "18" on line 2 (idx 15 → x = 72, y = 220).
+    num = 0;
+    ok = DetectNumericCitationInPageText(WStr(text, len), coords, len, Point{75, 224}, &num);
+    utassert(ok);
+    utassert(num == 18);
+    // Cursor on "17" on line 1 (idx 12 → x = 144).
+    num = 0;
+    ok = DetectNumericCitationInPageText(WStr(text, len), coords, len, Point{147, 206}, &num);
+    utassert(ok);
+    utassert(num == 17);
+}
+
+// (13e) Wrapped citation where the open bracket sits at the END of line 1
+// (high x) and the wrapped numbers are at the START of line 2 (low x) —
+// "...[42,\n43] maintain...". Mirrors the real "[42, 43]" failure: detection
+// walks by reading order (not x), so hovering "43" on line 2 must still find
+// the '[' on line 1 and resolve to 43.
+static void NumericCitationWrapEndOfLine() {
+    WCHAR text[256];
+    Rect coords[256];
+    int len = 0;
+    // Line 1 is a full column line ending in "[42," (the citation wrapped at
+    // the right margin); line 2 begins with "43]" at the left margin. The two
+    // share the column's x-range even though the citation halves do not.
+    AddText(text, coords, len, 256, L"a first line of text ending in [42,", 72, 200);
+    AddText(text, coords, len, 256, L"43] maintain live text here", 72, 224);
+    // '4' of the wrapped "43" is the first glyph of the 2nd line.
+    int idx43 = 0;
+    for (int i = 0; i < len; i++) {
+        if (text[i] == L'4' && coords[i].y == 224 && coords[i].x == 72) {
+            idx43 = i;
+            break;
+        }
+    }
+    utassert(idx43 > 0);
+    int num = 0;
+    // Cursor on the wrapped "43" (x=72, y=224).
+    bool ok = DetectNumericCitationInPageText(WStr(text, len), coords, len, Point{75, 230}, &num);
+    utassert(ok);
+    utassert(num == 43);
+    // Cursor on "42" at the end of line 1.
+    int idx42 = 0;
+    for (int i = 0; i < len; i++) {
+        if (text[i] == L'4' && coords[i].y == 200 && text[i + 1] == L'2') {
+            idx42 = i;
+            break;
+        }
+    }
+    utassert(idx42 > 0);
+    num = 0;
+    ok = DetectNumericCitationInPageText(WStr(text, len), coords, len, Point{coords[idx42].x + 3, 206}, &num);
+    utassert(ok);
+    utassert(num == 42);
+}
+
+// (13f) Wrapped citation whose glyphs are OUT OF READING ORDER in the array:
+// "[42," (line 1) and "43]" (line 2) are visually one line apart, but in the
+// glyph stream "43]" is preceded by unrelated text ~200pt above (mirrors the
+// real PDF: the stream neighbour of "43]" sat 196pt up, not at "[42,"). The
+// detector must reconstruct local reading order spatially and still resolve.
+static void NumericCitationWrapOutOfOrder() {
+    WCHAR text[512];
+    Rect coords[512];
+    int len = 0;
+    // line 1 (y=200): "...) [42," — the '[' sits near the right end.
+    AddText(text, coords, len, 512, L"runtime models [42,", 72, 200);
+    // Unrelated text ~200pt above, inserted BEFORE line 2 in array order so it
+    // becomes "43]"'s stream neighbour (as in the real doc).
+    AddText(text, coords, len, 512, L"unrelated heading text far above", 72, 4);
+    // line 2 (y=220): "43] maintain ..." — visually one line below line 1.
+    AddText(text, coords, len, 512, L"43] maintain live", 72, 220);
+    // '4' of "43" is the first glyph of the 3rd AddText run.
+    int idx43 = 0;
+    for (int i = 0; i < len; i++) {
+        if (text[i] == L'4' && coords[i].y == 220 && coords[i].x == 72) {
+            idx43 = i;
+            break;
+        }
+    }
+    utassert(idx43 > 0);
+    int num = 0;
+    // Cursor on the wrapped "43" (x=72, y=220).
+    bool ok = DetectNumericCitationInPageText(WStr(text, len), coords, len, Point{75, 226}, &num);
+    utassert(ok);
+    utassert(num == 43);
+}
+
+// (13g) Wrapped citation in the LEFT column of a 2-column page, with unrelated
+// right-column text at the same y. Column-limited segment reconstruction must
+// keep the right column out and still bridge "[42,"(line1) → "43]"(line2).
+static void NumericCitationWrapTwoColumn() {
+    WCHAR text[512];
+    Rect coords[512];
+    int len = 0;
+    // Left column (x=72, ends ~x=270). Line 1 ends "[42,", line 2 starts "43]".
+    AddText(text, coords, len, 512, L"left column line one ending [42,", 72, 200);
+    AddText(text, coords, len, 512, L"43] left column line two here", 72, 220);
+    // Right column (x=340) at the same two y's — must be ignored (gutter ~70pt).
+    AddText(text, coords, len, 512, L"right column first line text", 340, 200);
+    AddText(text, coords, len, 512, L"right column second line text", 340, 220);
+    // '4' of the wrapped "43" (left column, x=72, y=220).
+    int idx43 = 0;
+    for (int i = 0; i < len; i++) {
+        if (text[i] == L'4' && coords[i].x == 72 && coords[i].y == 220) {
+            idx43 = i;
+            break;
+        }
+    }
+    utassert(idx43 > 0);
+    int num = 0;
+    bool ok = DetectNumericCitationInPageText(WStr(text, len), coords, len, Point{75, 226}, &num);
+    utassert(ok);
+    utassert(num == 43);
+}
+
 // (10b) Two author-year citations on one line get distinct srcRect x spans.
 static void PlainTextCitationSrcRectDistinctOnLine() {
     WCHAR text[256];
@@ -758,10 +911,89 @@ static void TwoColumnWideSecondLineStaysInColumn() {
     utassert(box.x + box.dx < 300.f);
 }
 
+// (17) StripWatermarkGlyphs: a diagonal draft / "under review" watermark
+// (oversized glyphs, one per baseline) is removed, while body text and a
+// horizontal heading of same-baseline tall glyphs are kept.
+static void StripWatermarkRemovesDiagonalStamp() {
+    WCHAR text[1024];
+    Rect coords[1024];
+    int len = 0;
+    // Body: 3 lines of normal (dy=12) glyphs.
+    AddText(text, coords, len, 1024, L"normal body text line one here", 72, 200);
+    AddText(text, coords, len, 1024, L"normal body text line two here", 72, 214);
+    AddText(text, coords, len, 1024, L"normal body text line three xx", 72, 228);
+    int bodyGlyphs = len;
+    // Diagonal watermark: oversized (dy=40), each glyph on its own baseline.
+    for (int i = 0; i < 10 && len < 1024; i++) {
+        text[len] = L"UNDERREVIEW"[i];
+        coords[len] = Rect{190 + i * 14, 180 + i * 6, 20, 40};
+        len++;
+    }
+    WCHAR outText[1024];
+    Rect outCoords[1024];
+    int kept = StripWatermarkGlyphs(WStr(text, len), coords, outText, outCoords);
+    // All body glyphs survive; all 10 watermark glyphs are dropped.
+    utassert(kept == bodyGlyphs);
+    for (int i = 0; i < kept; i++) {
+        utassert(outCoords[i].dy == kLineH);
+    }
+
+    // A horizontal heading of tall glyphs (same baseline, many on the row) is
+    // NOT mistaken for a watermark — tall + dense row ⇒ kept.
+    len = 0;
+    AddText(text, coords, len, 1024, L"normal body text line one here", 72, 200);
+    int headStart = len;
+    for (int i = 0; i < 8 && len < 1024; i++) {
+        text[len] = L"HEADING!"[i];
+        coords[len] = Rect{72 + i * 14, 150, 12, 30}; // tall, but all share baseline 180
+        len++;
+    }
+    kept = StripWatermarkGlyphs(WStr(text, len), coords, outText, outCoords);
+    utassert(kept == len); // nothing stripped
+    (void)headStart;
+}
+
+// (18) 2-column reference list overlaid by a diagonal draft / "under review"
+// watermark whose oversized glyphs pass through the column gutter. The caller
+// strips the watermark (StripWatermarkGlyphs) before box detection, so the
+// gutter is empty again and the box stays in the left column. Regresses the
+// "ref spans two columns" bug: the watermark filled the gutter in the column
+// scan, columnRightX ran past it, and the box swept into the right column.
+static void TwoColumnWatermarkStaysInColumn() {
+    WCHAR text[1024];
+    Rect coords[1024];
+    int len = 0;
+    // Left column entry at x=72 (label+body share line 1, ends ~x=246), 2nd
+    // line at y=215. Right column body at x=340 (gutter ~246..340).
+    AddText(text, coords, len, 1024, L"[12] Sample left column entry", 72, 200);
+    AddText(text, coords, len, 1024, L"more left column entry text..", 72, 215);
+    for (int i = 0; i < 4; i++) {
+        AddText(text, coords, len, 1024, L"right column body text line..", 340, 200 + i * 15);
+    }
+    // Diagonal watermark: oversized (dy=40), wide (dx=20) glyphs stepping right
+    // by 14pt and down by 6pt, sweeping x≈190..360 across the gutter.
+    for (int i = 0; i < 12 && len < 1024; i++) {
+        text[len] = L"UNDERREVIEW.."[i];
+        coords[len] = Rect{190 + i * 14, 180 + i * 6, 20, 40};
+        len++;
+    }
+    // Caller pipeline: strip the watermark, then detect on the survivors.
+    WCHAR cleanText[1024];
+    Rect cleanCoords[1024];
+    int cleanLen = StripWatermarkGlyphs(WStr(text, len), coords, cleanText, cleanCoords);
+    RectF box = DetectEntryBox(WStr(cleanText, cleanLen), cleanCoords, Mediabox(), 72.f, 200.f);
+    utassert(!IsEmpty(box));
+    utassert(box.x <= 72.f + 6.f);
+    // must not cross the gutter into the right column (x=340)
+    utassert(box.x + box.dx < 340.f);
+}
+
 void RefHoverTest() {
     TwoColumnNumericLeftEntryNotHijacked();
     TwoColumnNumericReferenceFound();
     TwoColumnWideSecondLineStaysInColumn();
+    StripWatermarkRemovesDiagonalStamp();
+    TwoColumnWatermarkStaysInColumn();
     AccentedAllCapsHeadingDetected();
     HangingIndentNarrowLabelFullWidth();
     TwoColumnHangingIndentStaysInColumn();
@@ -792,5 +1024,10 @@ void RefHoverTest() {
     SurnameFoundOnBibPage();
     NumericCitationDetected();
     NumericCitationSrcRectDistinctOnLine();
+    NumericCitationRangeEnDash();
+    NumericCitationLineBreakList();
+    NumericCitationWrapEndOfLine();
+    NumericCitationWrapOutOfOrder();
+    NumericCitationWrapTwoColumn();
     NumericReferenceFoundOnBibPage();
 }


### PR DESCRIPTION
Three citation-hover fixes surfaced by a two-column IEEE proof with a diagonal "under review" watermark.

## Watermark strip (2-column popup spanned both columns)
A diagonal watermark crosses the column gutter, so `DetectEntryBox`'s gutter scan never finds an empty strip and `columnRightX` runs into the neighbouring column — the popup box then covers both. `StripWatermarkGlyphs` removes oversized glyphs that sit on sparse, similar-height baselines (a rotated stamp) while keeping headings (dense same-height rows). It runs once on the raw glyphs before `NormalizeGlyphLines`, in `RefHoverShow`, so both detectors see clean text.

## En-dash / em-dash page ranges
`[N]` citation detection accepted only the ASCII hyphen, so a typeset range like `[9–14]` (en-dash) broke bracket detection entirely. Now accepts figure/en/em dash and minus sign too.

## Wrapped numeric citations (`[42,\n43]`)
The index-based walk failed two ways in real PDFs: the glyph stream isn't in reading order across a line break (a wrapped number can sit ~200pt from its `[` in the array), and a naive y-band reconstruction merges both columns (burying the `[` behind the other column's text). `DetectNumericCitationInPageText` now rebuilds local reading order from **column-limited line segments** — the cursor line plus the nearest line above/below in the same column, each restricted to the contiguous x-run split at gutters — so `[42,` connects to `43]` without pulling in the neighbour column or the watermark.

## Tests
Unit tests added for watermark stripping (incl. heading-not-stripped), en-dash ranges, and wrapped citations (end-of-line, out-of-order glyph stream, two-column). Full `test_util` suite green apart from pre-existing unrelated `SettingsUtil`/`StrFormat` failures.

## Not included (parked)
- `[63]`-style entries that flow across the column break (left-column tail → right-column head) — needs a two-crop compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)