### PR TITLE
RefHover: show bracket entries that wrap across a column break

### DIFF
--- a/src/RefHover.h
+++ b/src/RefHover.h
@@ -66,6 +66,15 @@ struct RefHoverState {
         int pageNo = -1;
         float zoom = 0.f;
         RectF region{};
+        // Second crop stitched below `region` in the delivered bitmap, for a
+        // bracket-style entry that wraps across a 2-column page break (see
+        // DetectEntryBox's continuationOut). Empty (dx/dy <= 0) when there's
+        // none. Only ever set by the initial DetectEntryBox-driven show —
+        // wheel-zoom/scroll re-renders build a fresh request from just
+        // displayed.region and never populate this, so the stitched strip is
+        // dropped as soon as the user interacts (region-shift math for a
+        // composited bitmap isn't supported).
+        RectF continuationRegion{};
         // initial show: commit displayed.* and show the popup on completion.
         // false for wheel zoom / scroll re-renders, which update displayed.*
         // optimistically and only need the new bitmap.

--- a/src/RefHoverDetect.cpp
+++ b/src/RefHoverDetect.cpp
@@ -675,6 +675,231 @@ static void LineRunExtent(WStr text, const Rect* coords, int anchorIdx, int* lef
     *rightXOut = rightX;
 }
 
+// A bracket-style bibliography entry ("[63]") that runs to the bottom of its
+// 2-column-layout column with no sibling "[" and no blank-line gap closing it
+// may simply continue at the top of the next column (the column break falls
+// mid-entry). Look for that continuation: a block of body text starting at
+// the top of the column right of `oldColumnRightX` that does *not* itself
+// begin with a "[" label (which would mean it's the next real entry, not a
+// continuation). Returns an empty RectF when no such continuation is found.
+static RectF FindColumnWrapContinuation(WStr text, const Rect* coords, RectF mediabox, int oldColumnRightX) {
+    constexpr int kGutterW = 8;
+
+    // 1. Left edge of the next column: leftmost glyph right of the old
+    // column's right edge (skipping the gutter itself).
+    int nextColLeftX = INT_MAX;
+    for (int i = 0; i < text.len; i++) {
+        WCHAR c = text.s[i];
+        if (c == L' ' || c == L'\t' || c == L'\n' || c == L'\r') {
+            continue;
+        }
+        Rect r = coords[i];
+        if (r.x > oldColumnRightX + kGutterW && r.x < nextColLeftX) {
+            nextColLeftX = r.x;
+        }
+    }
+    if (nextColLeftX == INT_MAX) {
+        return RectF{};
+    }
+
+    // 2. Topmost line in the next column, and its leftmost X (candidate
+    // continuation start). Skip lines that bridge across the whole page width
+    // (a running header/title above both columns), and skip anything sitting
+    // in the page's top margin — a running header (page number, journal
+    // title) commonly renders as several short, column-confined fragments
+    // rather than one wide line, so the page-width check alone doesn't catch
+    // it. Real column body content essentially never starts this close to
+    // the physical page edge.
+    constexpr int kColWidthMax = 280;
+    constexpr int kMinTopMarginPt = 30;
+    int topY = INT_MAX;
+    for (int i = 0; i < text.len; i++) {
+        WCHAR c = text.s[i];
+        if (c == L' ' || c == L'\t' || c == L'\n' || c == L'\r') {
+            continue;
+        }
+        Rect r = coords[i];
+        if (r.x < nextColLeftX - 5 || r.y < kMinTopMarginPt) {
+            continue;
+        }
+        int leftIdx, leftX, rightX;
+        LineRunExtent(text, coords, i, &leftIdx, &leftX, &rightX);
+        if (rightX - leftX > kColWidthMax || leftX < nextColLeftX - 20) {
+            continue;
+        }
+        if (r.y < topY) {
+            topY = r.y;
+        }
+    }
+    if (topY == INT_MAX) {
+        return RectF{};
+    }
+    int topLeftX = INT_MAX;
+    int topDy = 12;
+    for (int i = 0; i < text.len; i++) {
+        WCHAR c = text.s[i];
+        if (c == L' ' || c == L'\t' || c == L'\n' || c == L'\r') {
+            continue;
+        }
+        Rect r = coords[i];
+        if (r.x < nextColLeftX - 5 || r.y < topY - 3 || r.y > topY + 3) {
+            continue;
+        }
+        if (r.x < topLeftX) {
+            topLeftX = r.x;
+            topDy = r.dy > 0 ? r.dy : 12;
+        }
+    }
+
+    // 3. Reject: the top line is itself a new entry's "[" label, not a
+    // continuation of the previous one.
+    for (int i = 0; i < text.len; i++) {
+        if (text.s[i] != L'[') {
+            continue;
+        }
+        Rect r = coords[i];
+        if (r.y >= topY - 3 && r.y <= topY + 3 && r.x >= topLeftX - 3 && r.x <= topLeftX + 3) {
+            return RectF{};
+        }
+    }
+
+    // 4. Right edge of the new column (gutter-bounded, mirrors the primary
+    // column-right scan in DetectEntryBox).
+    int colRightX = nextColLeftX + 250;
+    {
+        int bandTop = topY - 2;
+        int bandBot = topY + 6 * topDy;
+        int xLo = nextColLeftX - 5;
+        if (xLo < 0) {
+            xLo = 0;
+        }
+        int xHi = (int)mediabox.dx;
+        if (xHi > xLo + 2) {
+            int n = xHi - xLo;
+            char* occ = AllocArray<char>((size_t)n);
+            for (int i = 0; i < text.len; i++) {
+                WCHAR c = text.s[i];
+                if (c == L' ' || c == L'\t' || c == L'\n' || c == L'\r') {
+                    continue;
+                }
+                Rect r = coords[i];
+                if (r.y < bandTop || r.y > bandBot) {
+                    continue;
+                }
+                int a = r.x - xLo;
+                int b = r.x + r.dx - xLo;
+                if (b <= 0 || a >= n) {
+                    continue;
+                }
+                if (a < 0) {
+                    a = 0;
+                }
+                if (b > n) {
+                    b = n;
+                }
+                for (int x = a; x < b; x++) {
+                    occ[x] = 1;
+                }
+            }
+            int lastOcc = nextColLeftX;
+            for (int x = nextColLeftX; x < xHi; x++) {
+                int idx = x - xLo;
+                if (idx >= 0 && idx < n && occ[idx]) {
+                    lastOcc = x + 1;
+                } else if (x - lastOcc >= kGutterW) {
+                    break;
+                }
+            }
+            free(occ);
+            if (lastOcc > nextColLeftX) {
+                colRightX = lastOcc;
+            }
+        }
+    }
+
+    // 5. End of the continuation block. A real wrapped tail is short (finishes
+    // a sentence + a citation line or two), so cap the search tight — much
+    // tighter than a full entry's height cap in the primary scan above.
+    // Content that isn't closed by a sibling "[" (the following real entry)
+    // within that short cap is something else entirely (e.g. running body
+    // text that happens to share the column, ending in an unrelated "["
+    // many lines down) — reject rather than grab an arbitrary slice of it.
+    constexpr int kMaxContinuationPt = 60;
+    int capY = topY + kMaxContinuationPt;
+    int boundaryY = capY;
+    bool closedBySibling = false;
+    for (int i = 0; i < text.len; i++) {
+        if (text.s[i] != L'[') {
+            continue;
+        }
+        Rect r = coords[i];
+        if (r.x < nextColLeftX - 5 || r.x > nextColLeftX + 30) {
+            continue;
+        }
+        if (r.y <= topY + topDy / 2 || r.y >= capY) {
+            continue;
+        }
+        if (r.y < boundaryY) {
+            boundaryY = r.y;
+            closedBySibling = true;
+        }
+    }
+    if (!closedBySibling) {
+        // No sibling closed it within the cap. Still acceptable if the column
+        // has no more text at all past the cap (a short trailing tail that's
+        // simply the last thing in the column); reject if text keeps flowing
+        // past the cap, since that's not a short wrap.
+        for (int i = 0; i < text.len; i++) {
+            WCHAR c = text.s[i];
+            if (c == L' ' || c == L'\t' || c == L'\n' || c == L'\r') {
+                continue;
+            }
+            Rect r = coords[i];
+            if (r.x < nextColLeftX - 20 || r.x > colRightX) {
+                continue;
+            }
+            if (r.y >= capY - topDy) {
+                return RectF{};
+            }
+        }
+    }
+
+    // 6. Bounding box of the continuation block's glyphs.
+    int bMinX = INT_MAX, bMinY = INT_MAX, bMaxX = INT_MIN, bMaxY = INT_MIN;
+    for (int i = 0; i < text.len; i++) {
+        WCHAR c = text.s[i];
+        if (c == L' ' || c == L'\t' || c == L'\n' || c == L'\r') {
+            continue;
+        }
+        Rect r = coords[i];
+        if (r.x < nextColLeftX - 20 || r.x > colRightX) {
+            continue;
+        }
+        if (r.y < topY - 5 || r.y >= boundaryY) {
+            continue;
+        }
+        if (r.x < bMinX) {
+            bMinX = r.x;
+        }
+        if (r.y < bMinY) {
+            bMinY = r.y;
+        }
+        if (r.x + r.dx > bMaxX) {
+            bMaxX = r.x + r.dx;
+        }
+        if (r.y + r.dy > bMaxY) {
+            bMaxY = r.y + r.dy;
+        }
+    }
+    if (bMinX == INT_MAX || (bMaxX - bMinX) < 30 || (bMaxY - bMinY) < 8) {
+        return RectF{};
+    }
+    RectF box{(float)bMinX - kEntryPadPt, (float)bMinY - kEntryPadPt, (float)(bMaxX - bMinX) + 2.f * kEntryPadPt,
+              (float)(bMaxY - bMinY) + 2.f * kEntryPadPt};
+    ClipToMediabox(box, mediabox);
+    return box;
+}
+
 // Find the bounding box of a single bibliography entry on the destination
 // page. Uses per-glyph text+coords from the engine's text cache:
 //   1. Locate the leftmost glyph with y in a small band around destY (entry start).
@@ -685,7 +910,10 @@ static void LineRunExtent(WStr text, const Rect* coords, int anchorIdx, int* lef
 // (TOC, topbar, cross-ref, table caption). The landscape box renders a half-
 // page-tall slice of the page anchored on the destination so the user sees
 // surrounding context (e.g. the table rows under a caption).
-RectF DetectEntryBox(WStr text, const Rect* coords, RectF mediabox, float destX, float destY) {
+RectF DetectEntryBox(WStr text, const Rect* coords, RectF mediabox, float destX, float destY, RectF* continuationOut) {
+    if (continuationOut) {
+        *continuationOut = RectF{};
+    }
     // Sparse-text dest page (image-only or near-image-only — e.g. a
     // children's PDF overview with character thumbnails plus a single
     // heading). Fitting to the heading line gives a thin sliver and hides
@@ -996,6 +1224,11 @@ RectF DetectEntryBox(WStr text, const Rect* coords, RectF mediabox, float destX,
     // entry's body lines 2+. The y-range approach is order-independent.
     if (text.s[startIdx] == L'[') {
         int entryYBoundary = (int)mediabox.dy;
+        // Set when a sibling "[" was actually found below this entry — as
+        // opposed to entryYBoundary falling back to the page/cap bound because
+        // this is the column's last entry (see foundSibling use below, which
+        // feeds the column-wrap continuation search).
+        bool foundSibling = false;
         for (int i = 0; i < text.len; i++) {
             if (i == startIdx) {
                 continue;
@@ -1023,6 +1256,7 @@ RectF DetectEntryBox(WStr text, const Rect* coords, RectF mediabox, float destX,
             }
             if (r.y < entryYBoundary) {
                 entryYBoundary = r.y;
+                foundSibling = true;
             }
         }
         // Cap to a reasonable entry height so a last-on-page entry (no next
@@ -1120,6 +1354,54 @@ RectF DetectEntryBox(WStr text, const Rect* coords, RectF mediabox, float destX,
                       (float)(bMaxX - bMinX) + 2.f * kEntryPadPt, (float)(bMaxY - bMinY) + 2.f * kEntryPadPt};
             ClipToMediabox(box, mediabox);
             if (box.dx >= 50.f && box.dy >= 20.f) {
+                // No sibling "[" closed this entry, and — checked below — no
+                // more text at all follows in this column: this looks like the
+                // entry ran off the end of the column's content rather than
+                // ending naturally (a real paragraph gap with more text after
+                // it, which the trailing-gap trim above already accounts for).
+                // Distance to the physical page bottom isn't a reliable signal
+                // here: a column's last entry commonly sits well above the
+                // page's bottom margin. Check whether it continues at the top
+                // of the next column instead ("[63]"-style bibliography
+                // entries wrapping across a 2-column page break).
+                if (continuationOut && !foundSibling) {
+                    // A page footer / page number often sits within the same
+                    // x-range as the column, below the entry — that shouldn't
+                    // block the wrap search. Distance alone doesn't separate it
+                    // from a real continuation line (review-manuscript PDFs can
+                    // have the footer just a line or two below the last
+                    // entry), so instead measure each candidate line's full
+                    // width: a page number is a short isolated token, while a
+                    // real paragraph continuation line is (near-)column-width.
+                    constexpr int kMinBodyLineWidthPt = 30;
+                    bool moreBelowInColumn = false;
+                    for (int i = 0; i < text.len && !moreBelowInColumn; i++) {
+                        WCHAR c = text.s[i];
+                        if (c == L' ' || c == L'\t' || c == L'\n' || c == L'\r') {
+                            continue;
+                        }
+                        Rect r = coords[i];
+                        if (r.x < firstLineLeftX - 20 || r.x > columnRightX) {
+                            continue;
+                        }
+                        if (r.y <= bMaxY) {
+                            continue;
+                        }
+                        int leftIdx, leftX, rightX;
+                        LineRunExtent(text, coords, i, &leftIdx, &leftX, &rightX);
+                        // Confined to this column: a full-page-width footer
+                        // credit line (journal name / affiliation, common
+                        // below both columns) bridges clean across the gutter
+                        // and would otherwise read as "real" wide body text.
+                        bool confinedToColumn = rightX <= columnRightX + 10;
+                        if (rightX - leftX >= kMinBodyLineWidthPt && confinedToColumn) {
+                            moreBelowInColumn = true;
+                        }
+                    }
+                    if (!moreBelowInColumn) {
+                        *continuationOut = FindColumnWrapContinuation(text, coords, mediabox, columnRightX);
+                    }
+                }
                 return box;
             }
         }

--- a/src/RefHoverDetect.h
+++ b/src/RefHoverDetect.h
@@ -44,4 +44,11 @@ RectF DetectEquationBox(WStr text, const Rect* coords, RectF mediabox, float des
 // ("[Foo+09]"), hanging-indent author-year, and single-line description-list
 // layouts. Falls back to LandscapeBox when the destination doesn't look like
 // a list entry.
-RectF DetectEntryBox(WStr text, const Rect* coords, RectF mediabox, float destX, float destY);
+//
+// continuationOut, if non-null, is set to a second box when a bracket-style
+// entry runs off the bottom of its 2-column-layout column with no natural
+// close and continues at the top of the next column (e.g. "[63]"-style
+// entries wrapping across a column break); empty when there's no such
+// continuation. Ignored (left untouched) by callers that don't need it.
+RectF DetectEntryBox(WStr text, const Rect* coords, RectF mediabox, float destX, float destY,
+                     RectF* continuationOut = nullptr);

--- a/src/RefHoverPopup.cpp
+++ b/src/RefHoverPopup.cpp
@@ -23,6 +23,15 @@ static bool PopupClientToPagePt(RefHoverState* s, HWND hwnd, int clientX, int cl
         return false;
     }
     int border = DpiScale(hwnd, kRefHoverBorder);
+    // When a column-wrap continuation is stitched below displayed.region in
+    // the bitmap (see RefHoverRender.cpp's StackPixmapsVertically), a click
+    // there falls outside what displayed.region maps to — the formula below
+    // would silently produce a page point in the wrong place. Reject clicks
+    // past the primary crop's rendered height rather than mis-hit-test.
+    float regionPixH = s->displayed.region.dy * zoom;
+    if ((float)(clientY - border) > regionPixH) {
+        return false;
+    }
     ptOut.x = s->displayed.region.x + (float)(clientX - border) / zoom;
     ptOut.y = s->displayed.region.y + (float)(clientY - border) / zoom;
     return true;

--- a/src/RefHoverRender.cpp
+++ b/src/RefHoverRender.cpp
@@ -21,6 +21,63 @@ struct RefHoverRenderJob {
 
 static void RefHoverStartRenderJob(RefHoverRenderJob* job);
 
+// Stack `top` above `bottom` into one new DIB-backed Pixmap. Left-aligned —
+// the two crops come from different columns with unrelated absolute page-x
+// ranges (a right-column continuation sits ~200+pt right of a left-column
+// entry), so aligning by page coordinates would insert a large, arbitrary gap
+// rather than a small nudge. The narrower crop is padded on the right with
+// opaque white so it isn't stretched. Consumes neither input; caller frees
+// both. Returns nullptr on OOM.
+//
+// Uses GDI BitBlt rather than a raw pixel memcpy: EngineBase::RenderPage can
+// return a DIB at a bit depth other than 32bpp BGRA8 for near-monochrome
+// content (e.g. an 8bpp palette DIB for a text-only crop) — a straight
+// memcpy assuming 4 bytes/pixel then reads past each row's actual data and
+// produces colorful noise. BitBlt handles the source/dest bit-depth
+// conversion regardless of what RenderPage chose.
+static Pixmap* StackPixmapsVertically(Pixmap* top, Pixmap* bottom) {
+    int w = top->width > bottom->width ? top->width : bottom->width;
+    int h = top->height + bottom->height;
+    Pixmap* out = AllocPixmapDIB(w, h);
+    if (!out) {
+        return nullptr;
+    }
+    HDC screenDC = GetDC(nullptr);
+    HDC outDC = CreateCompatibleDC(screenDC);
+    HGDIOBJ oldOut = outDC ? SelectObject(outDC, out->hbmp) : nullptr;
+    if (outDC && oldOut) {
+        RECT full{0, 0, w, h};
+        HBRUSH white = CreateSolidBrush(RGB(255, 255, 255));
+        FillRect(outDC, &full, white);
+        DeleteObject(white);
+
+        if (top->hbmp) {
+            HDC topDC = CreateCompatibleDC(screenDC);
+            if (topDC) {
+                HGDIOBJ oldTop = SelectObject(topDC, top->hbmp);
+                BitBlt(outDC, 0, 0, top->width, top->height, topDC, 0, 0, SRCCOPY);
+                SelectObject(topDC, oldTop);
+                DeleteDC(topDC);
+            }
+        }
+        if (bottom->hbmp) {
+            HDC bottomDC = CreateCompatibleDC(screenDC);
+            if (bottomDC) {
+                HGDIOBJ oldBottom = SelectObject(bottomDC, bottom->hbmp);
+                BitBlt(outDC, 0, top->height, bottom->width, bottom->height, bottomDC, 0, 0, SRCCOPY);
+                SelectObject(bottomDC, oldBottom);
+                DeleteDC(bottomDC);
+            }
+        }
+        SelectObject(outDC, oldOut);
+    }
+    if (outDC) {
+        DeleteDC(outDC);
+    }
+    ReleaseDC(nullptr, screenDC);
+    return out;
+}
+
 static void RefHoverRenderDone(RefHoverRenderJob* job) {
     RefHoverState* s = job->s;
     if (!RefHoverIsLiveState(s)) {
@@ -64,6 +121,19 @@ static void RefHoverRenderDone(RefHoverRenderJob* job) {
 static void RefHoverRenderThread(RefHoverRenderJob* job) {
     RenderPageArgs args(job->req.pageNo, job->req.zoom, 0, &job->req.region);
     job->bmp = job->req.engine->RenderPage(args);
+    RectF cont = job->req.continuationRegion;
+    if (job->bmp && cont.dx > 0.f && cont.dy > 0.f) {
+        RenderPageArgs contArgs(job->req.pageNo, job->req.zoom, 0, &cont);
+        Pixmap* contBmp = job->req.engine->RenderPage(contArgs);
+        if (contBmp) {
+            Pixmap* stacked = StackPixmapsVertically(job->bmp, contBmp);
+            FreePixmap(contBmp);
+            if (stacked) {
+                FreePixmap(job->bmp);
+                job->bmp = stacked;
+            }
+        }
+    }
     job->req.engine->Release();
     job->req.engine = nullptr;
     auto fn = MkFunc0<RefHoverRenderJob>(RefHoverRenderDone, job);

--- a/src/RefHoverShow.cpp
+++ b/src/RefHoverShow.cpp
@@ -51,6 +51,10 @@ void RefHoverOnTimer(RefHoverState* s, HWND hwndCanvas, EngineBase* engine, floa
     }
 
     RectF region;
+    // Set when a bracket-style entry wraps across a 2-column page break (e.g.
+    // "[63]"): a second crop, stitched below `region` in the delivered
+    // bitmap. Empty (dx/dy <= 0) otherwise.
+    RectF continuation{};
     if (useLinkZoom) {
         region = RectF{0.f, destY, mediabox.dx, mediabox.dy - destY};
     } else {
@@ -72,7 +76,7 @@ void RefHoverOnTimer(RefHoverState* s, HWND hwndCanvas, EngineBase* engine, floa
         }
         region = DetectEquationBox(text, normCoords, mediabox, destX, destY);
         if (region.dx <= 0.f || region.dy <= 0.f) {
-            region = DetectEntryBox(text, normCoords, mediabox, destX, destY);
+            region = DetectEntryBox(text, normCoords, mediabox, destX, destY, &continuation);
         }
         if (normCoords != coords) {
             free(normCoords);
@@ -80,6 +84,7 @@ void RefHoverOnTimer(RefHoverState* s, HWND hwndCanvas, EngineBase* engine, floa
         free(cleanText);
         free(cleanCoords);
     }
+    bool hasContinuation = continuation.dx > 0.f && continuation.dy > 0.f;
     s->displayed.userZoom = 1.f;
     float baseZoom = useLinkZoom ? linkZoom : ((pageZoom > 0.f) ? pageZoom : kRefHoverRenderZoom);
 
@@ -97,9 +102,14 @@ void RefHoverOnTimer(RefHoverState* s, HWND hwndCanvas, EngineBase* engine, floa
             }
         }
     }
+    // Combined content extent (region stacked above continuation, if any) used
+    // for sizing below; req.region itself stays just the primary crop.
+    float contentDy = region.dy + (hasContinuation ? continuation.dy : 0.f);
+    float contentDx = hasContinuation && continuation.dx > region.dx ? continuation.dx : region.dx;
+
     int popupHCap;
     int cursorPad = DpiScale(s->hwndPopup, kRefHoverCursorPad);
-    if (region.dy > 250.f && s->pending.pageScreenRect.dy > 0) {
+    if (contentDy > 250.f && s->pending.pageScreenRect.dy > 0) {
         Rect pr = s->pending.pageScreenRect;
         int curY = s->pending.screenPt.y;
         int spaceAbove = curY - pr.y - cursorPad;
@@ -142,11 +152,11 @@ void RefHoverOnTimer(RefHoverState* s, HWND hwndCanvas, EngineBase* engine, floa
         region.dx = wantW;
         region.dy = wantH;
     } else {
-        if (region.dy > 0.f && region.dy * baseZoom > availH) {
-            baseZoom = availH / region.dy;
+        if (contentDy > 0.f && contentDy * baseZoom > availH) {
+            baseZoom = availH / contentDy;
         }
-        if (region.dx > 0.f && region.dx * baseZoom > availW) {
-            baseZoom = availW / region.dx;
+        if (contentDx > 0.f && contentDx * baseZoom > availW) {
+            baseZoom = availW / contentDx;
         }
     }
     if (baseZoom < kRefHoverMinUserZoom) {
@@ -158,6 +168,9 @@ void RefHoverOnTimer(RefHoverState* s, HWND hwndCanvas, EngineBase* engine, floa
     req.pageNo = destPage;
     req.zoom = s->displayed.baseZoom * s->displayed.userZoom;
     req.region = region;
+    if (hasContinuation) {
+        req.continuationRegion = continuation;
+    }
     req.showPopup = true;
     req.screenPt = s->pending.screenPt;
     req.destXRaw = s->pending.destX;

--- a/src/base/tests/RefHover_ut.cpp
+++ b/src/base/tests/RefHover_ut.cpp
@@ -183,6 +183,56 @@ static void TwoColumnLeftEntryStaysInColumn() {
     utassert(box.y + box.dy < 240.f);
 }
 
+// (3g) Bracket entry wraps across a 2-column page break ("[63]"-style): the
+// last entry in the left column ends near the page bottom with no sibling
+// "[" or blank-line gap to close it, and continues at the top of the next
+// column. DetectEntryBox must report that continuation via continuationOut
+// without swallowing the following entry ("[64]") in the new column.
+static void ColumnWrapContinuationDetected() {
+    WCHAR text[1024];
+    Rect coords[1024];
+    int len = 0;
+    // Left column's last entry: single line near the page bottom (kPageH=792).
+    AddText(text, coords, len, 1024, L"[63] Voelter M: DSL Engineering des", 72, 762);
+    // Right column (gutter ~252..340): continuation of [63] at the top (no
+    // bracket label), then the next real entry [64] further down.
+    AddText(text, coords, len, 1024, L"Languages dslbook org Germany 2013", 340, 40);
+    AddText(text, coords, len, 1024, L"[64] Moretti N Xie X et al Title", 340, 65);
+    RectF continuation{};
+    RectF box = DetectEntryBox(WStr(text, len), coords, Mediabox(), 72.f, 762.f, &continuation);
+    utassert(!IsEmpty(box));
+    // Primary box unaffected: stays in the left column, at the entry's line.
+    utassert(box.x < 246.f);
+    utassert(box.y <= 762.f + 6.f);
+    utassert(!IsEmpty(continuation));
+    // Continuation sits in the right column, above the next entry.
+    utassert(continuation.x > 246.f);
+    utassert(continuation.y <= 40.f + 6.f);
+    utassert(continuation.y + continuation.dy < 65.f);
+}
+
+// (3h) Last entry in the left column ends near the column's content edge, but
+// the top of the next column is unrelated running body text (e.g. a
+// Discussion section sharing the page with References, not a wrap of this
+// entry) that only reaches a bracket many lines down. DetectEntryBox must not
+// mistake that long unrelated block for a short wrapped tail.
+static void ColumnWrapContinuationRejectsUnrelatedBodyText() {
+    WCHAR text[1024];
+    Rect coords[1024];
+    int len = 0;
+    AddText(text, coords, len, 1024, L"[47] Zhang X Wang Y Wang J Title A", 72, 750);
+    // Right column: several lines of unrelated running text, then a sibling
+    // entry far past the short continuation cap.
+    for (int i = 0; i < 6; i++) {
+        AddText(text, coords, len, 1024, L"unrelated running body text here.", 340, 40 + i * 14);
+    }
+    AddText(text, coords, len, 1024, L"[48] Li H Hou L Wang X Guo H Title", 340, 130);
+    RectF continuation{};
+    RectF box = DetectEntryBox(WStr(text, len), coords, Mediabox(), 72.f, 750.f, &continuation);
+    utassert(!IsEmpty(box));
+    utassert(IsEmpty(continuation));
+}
+
 // (3c) All-caps accented Spanish heading "SECCIÓN 2": the heading-prefix
 // dictionary must match case-insensitively beyond ASCII (the process runs in
 // the "C" locale where towlower doesn't fold Ó), so the destination is
@@ -1018,6 +1068,8 @@ void RefHoverTest() {
     SparseTextReturnsWholePage();
     TwoColumnLeftEntryStaysInColumn();
     TwoColumnRightEntryStaysInColumn();
+    ColumnWrapContinuationDetected();
+    ColumnWrapContinuationRejectsUnrelatedBodyText();
     PlainTextCitationDetected();
     PlainTextCitationSrcRectDistinctOnLine();
     PlainTextCitationNoYear();


### PR DESCRIPTION
## Summary
- Bracket-style bibliography entries ("[63]") that run off the bottom of their column with no sibling "[" or blank-line gap now get detected as wrapping into the top of the next column, and the popup shows both fragments stitched together.
- Fixes a stitching bug found while testing on a real 2-column manuscript PDF: `RenderPage` can return a non-32bpp palette DIB for near-monochrome text crops, so the stitcher now uses GDI `BitBlt` instead of a raw pixel memcpy.
- The continuation search distinguishes a real wrapped tail from page footers/numbers, full-width footer/header lines, and unrelated running body text sharing the page — using column confinement and a tight closing cap rather than a fixed distance-to-page-bottom threshold (real margins vary too much for that to be reliable).
- Wheel zoom/scroll continue to operate on just the primary region as before (untouched code paths) — the stitched continuation only appears on the initial popup show and is dropped on any interaction.
- Click-to-open-link hit test now rejects clicks landing in the stitched continuation strip instead of mis-mapping them to the wrong page point.

## Test plan
- [x] `test_util.exe`: all RefHover unit tests pass (2 new: `ColumnWrapContinuationDetected`, `ColumnWrapContinuationRejectsUnrelatedBodyText`), same 8 pre-existing unrelated failures elsewhere
- [x] Full `SumatraPDF.exe` build succeeds
- [x] Manually verified against a real 2-column IEEE-style manuscript PDF with wrapped bibliography entries (both a synthetic case and two real-world entries, including one requiring several detection fixes for footer/header false positives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)