### PR TITLE
Fix native Linux build and add a native Linux CI job

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -47,3 +47,32 @@ jobs:
         with:
           name: SumatraPDF-linux-wine-debug
           path: out/dbg64-wine/SumatraPDF.exe
+
+  native:
+    name: Native build and unit tests
+    runs-on: ubuntu-latest
+    container: debian:trixie
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v7
+
+      - name: Install clang, OpenSSL headers and bun
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential clang lld libssl-dev \
+            ca-certificates curl unzip git
+          curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash
+
+      # builds all dependency libs, runs test_util's unit-test suite
+      # natively, and links test_engines
+      - name: Build dependencies and run native unit tests
+        run: bun cmd/build-linux.ts -debug
+
+      - name: Upload test tools
+        uses: actions/upload-artifact@v7
+        with:
+          name: sumatra-linux-native-tools
+          path: |
+            out/linux-dbg64/test_util
+            out/linux-dbg64/test_engines

--- a/cmd/build-linux.ts
+++ b/cmd/build-linux.ts
@@ -30,6 +30,7 @@ import {
   spawnCmd,
 } from "./build-deps-common";
 import {
+  aGumbo,
   zlib,
   unrar,
   libwebp,
@@ -594,6 +595,7 @@ const DEP_LIBS_BASE = [
       },
     ],
   },
+  aGumbo,
   zlib,
   makeUnrar,
   makeLibdjvu,
@@ -623,7 +625,12 @@ const TEST_UTIL_SOURCES = [
   "src/Commands.cpp",
   "src/CrashHandlerNoOp.cpp",
   "src/DisplayMode.cpp",
+  "src/DocProperties.cpp",
   "src/Flags.cpp",
+  "src/PdfDarkModeImageClassifier_ut.cpp",
+  "src/PdfDarkModeImageRules.cpp",
+  "src/PdfDarkModeOklab.cpp",
+  "src/PdfDarkModeOklab_ut.cpp",
   "src/RefHoverDetect.cpp",
   "src/RefHoverTextDetect.cpp",
   "src/SimpleLog_ut.cpp",
@@ -663,6 +670,9 @@ const TEST_ENGINES_SOURCES = [
   "src/GumboHelpers.cpp",
   "src/MobiDoc.cpp",
   "src/PalmDbReader.cpp",
+  "src/PdfCadDetect.cpp",
+  "src/PdfCadEnhanceDevice.cpp",
+  "src/PdfDarkModeNoOp.cpp",
   "src/TreeModel.cpp",
   "src/tools/test_engines.cpp",
 ];
@@ -880,6 +890,7 @@ async function buildTestUtil(
     ...commonFlags,
     ...units.map((u) => u.obj),
     join(outDir, "lib", "libbase.a"),
+    "-lcrypto",
   ];
   const res = await spawnCmd(linkArgs);
   if (!res.ok) {
@@ -957,6 +968,7 @@ async function buildTestEngines(
     exePath,
     ...commonFlags,
     ...units.map((u) => u.obj),
+    "-Wl,--start-group",
     join(outDir, "lib", "libbase.a"),
     join(outDir, "lib", "libmupdf.a"),
     join(outDir, "lib", "libcmark-gfm.a"),
@@ -966,12 +978,15 @@ async function buildTestEngines(
     join(outDir, "lib", "libfreetype.a"),
     join(outDir, "lib", "libbrotli.a"),
     join(outDir, "lib", "liblcms2.a"),
-    join(outDir, "lib", "libopenjpeg.a"),
+    join(outDir, "lib", "liba-openjpeg.a"),
     join(outDir, "lib", "libjbig2dec.a"),
     join(outDir, "lib", "liblibjpeg-turbo.a"),
     join(outDir, "lib", "libdjvudec.a"),
     join(outDir, "lib", "liblibarchive.a"),
-    join(outDir, "lib", "libzlib.a"),
+    join(outDir, "lib", "liba-gumbo.a"),
+    join(outDir, "lib", "liba-zlib.a"),
+    "-Wl,--end-group",
+    "-lcrypto",
   ];
   const res = await spawnCmd(linkArgs);
   if (!res.ok) {

--- a/ext/a-openjpeg/opj_malloc.h
+++ b/ext/a-openjpeg/opj_malloc.h
@@ -19,6 +19,12 @@ void * opj_realloc(void * m, size_t s);
 void opj_free(void * m);
 
 #if defined(__GNUC__) && !defined(OPJ_SKIP_POISON)
+/* clang (unlike gcc) enforces poison inside system headers, and mm_malloc.h
+   (pulled in by the SSE intrinsic headers) calls malloc/free. Include the
+   intrinsics before poisoning so later includes are no-ops via include guards. */
+#if defined(__x86_64__) || defined(__i386__)
+#include <immintrin.h>
+#endif
 #pragma GCC poison malloc calloc realloc free
 #endif
 


### PR DESCRIPTION
🤖 *This description was generated by Claude Code.*

**Stacked on #5812** (`linux-wine-ci`) — it needs that PR's shared lib-def fixes. GitHub will retarget this to `master` automatically when the base PR merges and its branch is deleted.

## What

`cmd/build-linux.ts` (native Linux build of all dependency libs plus the portable `test_util` / `test_engines` tools) had drifted from premake and from recent source changes:

- `test_util` sources synced with premake: `DocProperties.cpp`, `PdfDarkModeImageRules/Oklab.cpp` and their `_ut` tests — all called unconditionally by `test_util.cpp` and `SumatraUnitTests.cpp`, so the link was broken
- `test_engines`: add the `a-gumbo` dependency lib (`GumboHtmlParser` needs it) and the `PdfCadDetect` / `PdfCadEnhanceDevice` / `PdfDarkModeNoOp` sources premake lists for it
- stale archive names in the link list (`libzlib.a` / `libopenjpeg.a` → `liba-zlib.a` / `liba-openjpeg.a`)
- link `-lcrypto`: `Crypto_posix.cpp` uses OpenSSL's MD5 (the native build now needs `libssl-dev`)
- wrap the `test_engines` archives in `-Wl,--start-group`: harfbuzz is built with custom allocators (`sumatra_hb_*`) whose definitions live in mupdf's `mupdf_load_system_font.c`, behind harfbuzz in link order — single-pass ld can't resolve that without a group

**`ext/a-openjpeg/opj_malloc.h`:** include the x86 intrinsic headers before the `#pragma GCC poison malloc …`. clang — unlike gcc — enforces poison inside system headers, and `mm_malloc.h` (pulled in by the SSE headers that a later chunk of the amalgamation includes) calls `malloc`. Never seen on macOS because arm64 has no `xmmintrin.h`. (Note: regenerating the amalgamation via `cmd/a-openjpeg.ts` would drop this line; its own `validateCompile` step will catch that.)

**CI:** extends `.github/workflows/linux.yml` with a `native` job (same `debian:trixie` container): builds all dependency libs with clang, runs `test_util`'s unit-test suite natively on Linux as part of the build, and links `test_engines`.

## How tested

On Linux, inside a `debian:trixie` container (same as the CI job):

```
bun cmd/build-linux.ts -debug
# -> all dependency libs build
# -> out/linux-dbg64/test_util links and its unit-test suite passes (run by the build)
# -> out/linux-dbg64/test_engines links
```

The workflow job was validated locally with `nektos/act` in the same container. No Windows-facing changes in this PR (`build-linux.ts` is Linux-only; the `opj_malloc.h` change is inside `#if defined(__GNUC__)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
