### PR TITLE
Add EnableReadAloud advanced setting to hide Read Aloud UI

### DIFF
--- a/cmd/gen-settings.ts
+++ b/cmd/gen-settings.ts
@@ -880,6 +880,12 @@ const globalPrefs: Field[] = [
     .internal()
     .ver("3.7"),
   field(
+    "EnableReadAloud",
+    Bool,
+    true,
+    "if false, hide the Read Aloud (text-to-speech) toolbar button, menu, and command palette entries",
+  ).ver("3.7"),
+  field(
     "ShowToolbar",
     Bool,
     true,

--- a/docs/md/Advanced-options-settings.md
+++ b/docs/md/Advanced-options-settings.md
@@ -118,6 +118,10 @@ ShowTips = true
 ; (e.g. '#ff0000 #00ff00 #0000ff') (introduced in version 3.7)
 CustomColors =
 
+; if false, hide the Read Aloud (text-to-speech) toolbar button, menu, and
+; command palette entries (introduced in version 3.7)
+EnableReadAloud = true
+
 ; legacy bool for toolbar; if Toolbar is empty, derived as show/hide (internal;
 ; use Toolbar instead)
 ShowToolbar = true

--- a/docs/md/Version-history.md
+++ b/docs/md/Version-history.md
@@ -28,6 +28,7 @@ Available in [pre-release](https://www.sumatrapdfreader.org/prerelease) builds.
 - Markdown documents have a **Show Generated HTML** command (`Ctrl + K` command palette) that saves the rendered HTML to a temporary `.html` file and opens it in Notepad
 - HEIC / HEIF still images now decode with a built-in decoder (no Windows HEIC codec required for most phone photos); AVIF still uses dav1d. The system WIC path remains as a fallback if built-in decode fails
 - Read Aloud: adjustable playback speed — pick 0.5x .. 3x in the new `Speed` submenu (next to `Voice` in the Read Aloud menu, toolbar dropdown and context menu) or click the speed button on the playback bar to cycle presets (right-click cycles backwards); the speed persists across sessions via the `ReadAloudSpeed` advanced setting
+- Read Aloud can be hidden entirely (toolbar button, menu, and command palette entries) by setting `EnableReadAloud = false` in `SumatraPDF-settings.txt`, for people who don't use text-to-speech and want a leaner toolbar/menu (discussion #5670)
 - updated the bundled MuPDF rendering engine to 1.28.0
 - add [AI Chat with document](AI-Chat-with-document.md) sidebar (in View menu and `Ctrl + k` [command palette](Command-Palette.md)) for asking questions about the open PDF or image via [Claude Code](https://docs.anthropic.com/en/docs/claude-code); per-tab session state, model/effort selection, and session history from `~/.claude/projects/`
 - add `ClaudeCode` advanced settings (`Model`, `Effort`, `SkipPermissions`, `BgColor`, `SidebarDx`) in `SumatraPDF-settings.txt`

--- a/src/CommandAvailability.cpp
+++ b/src/CommandAvailability.cpp
@@ -134,6 +134,18 @@ static UINT_PTR removeIfNoFullscreenPerms[] = {
     0,
 };
 
+// hidden from toolbar, menu, context menu and command palette when the
+// EnableReadAloud advanced setting is turned off
+static UINT_PTR removeIfReadAloudDisabled[] = {
+    CmdReadAloud,
+    CmdPauseReadAloud,
+    CmdContinueReadAloud,
+    CmdStopReadAloud,
+    CmdReadAloudFromTopPage,
+    CmdReadAloudSelection,
+    0,
+};
+
 static UINT_PTR removeIfNoPrefsPerms[] = {
     CmdOptions,
     CmdSetInverseSearch,
@@ -636,6 +648,9 @@ CommandVisibility GetCommandVisibility(int cmdId, const AppCommandCtx& ctx, Comm
         return CommandVisibility::Hide;
     }
     if (!HasPermission(Perm::PrinterAccess) && cmdId == CmdPrint) {
+        return CommandVisibility::Hide;
+    }
+    if (!gGlobalPrefs->enableReadAloud && CmdIdInList(cmdId, removeIfReadAloudDisabled)) {
         return CommandVisibility::Hide;
     }
     if (!CanAccessDisk()) {

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1916,6 +1916,9 @@ void OnWindowContextMenu(MainWindow* win, int x, int y) {
 
     auto* ctx = NewBuildMenuCtx(tab, cursorPos);
     AutoDelete delCtx(ctx);
+    // avoid a dangling handle if the Read Aloud submenu ends up empty this
+    // time (e.g. EnableReadAloud is off) and BuildMenuFromDef never re-sets it
+    SetReadAloudContextSubmenu(nullptr);
     HMENU popup = BuildMenuFromDef(menuDefContext, CreatePopupMenu(), ctx);
 
     // in fullscreen, add "Menu" as first item containing the full menu bar

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -633,6 +633,9 @@ struct GlobalPrefs {
     // up to 13 custom colors for the background color picker, separated by
     // space (e.g. '#ff0000 #00ff00 #0000ff')
     Str customColors;
+    // if false, hide the Read Aloud (text-to-speech) toolbar button, menu,
+    // and command palette entries
+    bool enableReadAloud;
     // legacy bool for toolbar; if Toolbar is empty, derived as show/hide
     // (internal; use Toolbar instead)
     bool showToolbar;
@@ -1521,6 +1524,7 @@ static const FieldInfo gGlobalPrefsFields[] = {
     {offsetof(GlobalPrefs, showMenubarWithTabs), SettingType::Bool, false},
     {offsetof(GlobalPrefs, showTips), SettingType::Bool, true},
     {offsetof(GlobalPrefs, customColors), SettingType::String, 0, true},
+    {offsetof(GlobalPrefs, enableReadAloud), SettingType::Bool, true},
     {offsetof(GlobalPrefs, showToolbar), SettingType::Bool, true, true},
     {offsetof(GlobalPrefs, toolbar), SettingType::String, 0},
     {offsetof(GlobalPrefs, toolbarPosition), SettingType::String, (intptr_t)"top"},
@@ -1632,18 +1636,18 @@ static const StructInfo gGlobalPrefsInfo = {
     "\0\0DefaultDisplayMode\0DefaultZoom\0DisableJavaScript\0AllowExternalImages\0EnableTeXEnhancements\0EscToExit\0Ful"
     "lPathInTitle\0InverseSearchCmdLine\0LazyLoading\0MainWindowBackground\0NoHomeTab\0HomePageSortByFrequentlyRead\0Ho"
     "mePageViewMode\0ReloadModifiedDocuments\0RememberOpenedFiles\0RememberStatePerDocument\0RestoreSession\0ReuseInsta"
-    "nce\0ShowMenubar\0ShowMenubarWithTabs\0ShowTips\0CustomColors\0ShowToolbar\0Toolbar\0ToolbarPosition\0SearchUIFloa"
-    "ting\0ShowFavorites\0SortFavoritesByName\0ShowToc\0ShowLinks\0ShowDocumentFocusIndicator\0ShowAnnotationNotificati"
-    "on\0ShowTocPageNumbers\0ShowStartPage\0SidebarDx\0Scrollbars\0ScrollbarInSinglePage\0SmoothScroll\0PaddingAfterLas"
-    "tPage\0CitationHoverDelay\0ReadAloudVoiceId\0ReadAloudSpeed\0FastScrollOverScrollbar\0PreventSleepInFullscreen\0Ta"
-    "bWidth\0Theme\0LastLightTheme\0LastDarkTheme\0DocumentColorsFollowTheme\0TocDy\0ToolbarShowReadAloud\0ToolbarSize"
-    "\0TreeFontName\0TreeFontSize\0UIFontSize\0DisableAntiAlias\0EngineeringDrawingEnhance\0DisableAutoLinks\0UseSysCol"
-    "ors\0UseTabs\0SelectionToolbar\0TabsMru\0ZoomLevels\0ZoomIncrement\0\0FixedPageUI\0\0EBookUI\0\0ComicBookUI\0\0Ima"
-    "geUI\0\0ChmUI\0\0MarkdownUI\0\0ClaudeCode\0\0GrokBuild\0\0CodexBuild\0\0AIChatSidebarDx\0\0TranslateToLang\0Transl"
-    "ateFromLang\0TranslateEngine\0\0Annotations\0\0ExternalViewers\0\0ForwardSearch\0\0PrinterDefaults\0\0Fullscreen\0"
-    "\0SelectionHandlers\0\0Shortcuts\0\0Themes\0\0TabGroups\0\0CustomScreenDPI\0\0\0DefaultPasswords\0UiLanguage\0Vers"
-    "ionToSkip\0WindowState\0WindowPos\0SearchUIWindowPos\0FileStates\0SessionData\0ReopenOnce\0TimeOfLastUpdateCheck\0"
-    "OpenCountWeek\0PropWinPos\0CheckForUpdates\0\0",
+    "nce\0ShowMenubar\0ShowMenubarWithTabs\0ShowTips\0CustomColors\0EnableReadAloud\0ShowToolbar\0Toolbar\0ToolbarPosit"
+    "ion\0SearchUIFloating\0ShowFavorites\0SortFavoritesByName\0ShowToc\0ShowLinks\0ShowDocumentFocusIndicator\0ShowAnn"
+    "otationNotification\0ShowTocPageNumbers\0ShowStartPage\0SidebarDx\0Scrollbars\0ScrollbarInSinglePage\0SmoothScroll"
+    "\0PaddingAfterLastPage\0CitationHoverDelay\0ReadAloudVoiceId\0ReadAloudSpeed\0FastScrollOverScrollbar\0PreventSlee"
+    "pInFullscreen\0TabWidth\0Theme\0LastLightTheme\0LastDarkTheme\0DocumentColorsFollowTheme\0TocDy\0ToolbarShowReadAl"
+    "oud\0ToolbarSize\0TreeFontName\0TreeFontSize\0UIFontSize\0DisableAntiAlias\0EngineeringDrawingEnhance\0DisableAuto"
+    "Links\0UseSysColors\0UseTabs\0SelectionToolbar\0TabsMru\0ZoomLevels\0ZoomIncrement\0\0FixedPageUI\0\0EBookUI\0\0Co"
+    "micBookUI\0\0ImageUI\0\0ChmUI\0\0MarkdownUI\0\0ClaudeCode\0\0GrokBuild\0\0CodexBuild\0\0AIChatSidebarDx\0\0Transla"
+    "teToLang\0TranslateFromLang\0TranslateEngine\0\0Annotations\0\0ExternalViewers\0\0ForwardSearch\0\0PrinterDefaults"
+    "\0\0Fullscreen\0\0SelectionHandlers\0\0Shortcuts\0\0Themes\0\0TabGroups\0\0CustomScreenDPI\0\0\0DefaultPasswords\0"
+    "UiLanguage\0VersionToSkip\0WindowState\0WindowPos\0SearchUIWindowPos\0FileStates\0SessionData\0ReopenOnce\0TimeOfL"
+    "astUpdateCheck\0OpenCountWeek\0PropWinPos\0CheckForUpdates\0\0",
     "\0\0default layout of pages. valid values: automatic, single page, facing, book view, continuous, continuous "
     "facing, continuous book view\0default zoom. valid values: fit page, fit width, fit height, fit content or percent "
     "like 100%\0if true, JavaScript in PDF documents is disabled (e.g. form-field calculations won't run)\0if true, a "
@@ -1663,12 +1667,13 @@ static const StructInfo gGlobalPrefsInfo = {
     "true, open documents in the already running SumatraPDF instead of starting a new one\0if true, show the menu bar "
     "(F9 toggles it; the choice is remembered across sessions)\0if true, show the menu bar when using tabs (useTabs = "
     "true)\0if true, show tips on the home page\0up to 13 custom colors for the background color picker, separated by "
-    "space (e.g. '#ff0000 #00ff00 #0000ff')\0legacy bool for toolbar; if Toolbar is empty, derived as show/hide "
-    "(internal; use Toolbar instead)\0toolbar mode: show (pinned), hide (no toolbar), overlay (toolbar floats over the "
-    "page, sized to its natural width and centered, only shown when the mouse is near it). if empty, derived from "
-    "ShowToolbar\0where the toolbar is placed: top or bottom (applies to both show and overlay modes)\0if true, the "
-    "find UI is a floating, movable window with a results list instead of the compact toolbar overlay\0if true, show "
-    "the Favorites sidebar\0if true, favorites within each file are sorted alphabetically by name (or page label); if "
+    "space (e.g. '#ff0000 #00ff00 #0000ff')\0if false, hide the Read Aloud (text-to-speech) toolbar button, menu, and "
+    "command palette entries\0legacy bool for toolbar; if Toolbar is empty, derived as show/hide (internal; use "
+    "Toolbar instead)\0toolbar mode: show (pinned), hide (no toolbar), overlay (toolbar floats over the page, sized "
+    "to its natural width and centered, only shown when the mouse is near it). if empty, derived from ShowToolbar\0"
+    "where the toolbar is placed: top or bottom (applies to both show and overlay modes)\0if true, the find UI is a "
+    "floating, movable window with a results list instead of the compact toolbar overlay\0if true, show the "
+    "Favorites sidebar\0if true, favorites within each file are sorted alphabetically by name (or page label); if "
     "false (the default), they are sorted by page number\0if true, show the table of contents (Bookmarks) sidebar when "
     "the document has one\0if true, draw a blue border around links in the document\0if true, draw a focus ring around "
     "the document when it has keyboard focus (Tab to the page area)\0if true, show a tip when hovering an annotation "

--- a/src/SumatraPDF.cpp
+++ b/src/SumatraPDF.cpp
@@ -12173,6 +12173,9 @@ static void BuildReadAloudVoiceMenuItems(HMENU voiceMenu) {
 }
 
 static void BuildReadAloudMenuItems(HMENU menu, MainWindow* win, bool includeCursorItem, bool canReadFromCursor) {
+    if (!gGlobalPrefs->enableReadAloud) {
+        return;
+    }
     WindowTab* currTab = win ? win->CurrentTab() : nullptr;
     bool isSpeaking = TtsIsSpeaking();
     bool canContinue = CanContinueReadAloud(currTab);


### PR DESCRIPTION
> This PR was generated with AI assistance (Claude), based on a request in discussion #5670.

Adds an `EnableReadAloud` advanced setting (default `true`) that hides the Read Aloud (text-to-speech) toolbar button, top-level menu, context menu entry, and command palette entries when set to `false`, so people who don't use TTS can keep a leaner UI. Set `EnableReadAloud = false` in `SumatraPDF-settings.txt`, or toggle it from the new **Advanced Settings...** dialog (Ctrl+K), it shows up there automatically since that dialog is built from the settings reflection data.

Suggested here: https://github.com/sumatrapdfreader/sumatrapdf/discussions/5670#discussioncomment-17792459.

Implementation notes:

- `GetCommandVisibility()` in `CommandAvailability.cpp` is the single choke point already used by the toolbar, the main menu, the context menu, and the command palette. Gating the six `CmdReadAloud*` command ids there (behind `!gGlobalPrefs->enableReadAloud`) hides the feature everywhere at once instead of touching four separate code paths.
- The top-level "Read Aloud (TTS)" menu doesn't need an explicit remove check: `BuildReadAloudMenuItems()` just returns early when the setting is off, and `BuildMenuFromDef()` already drops any submenu that ends up empty.
- One subtlety: the context-menu variant of that submenu is tracked through a static `HMENU` (`gReadAloudContextSubmenu`), refreshed on every right-click via `SetReadAloudContextSubmenu()`. Before this change that refresh always happened because the submenu was never empty. With `EnableReadAloud = false` it can now legitimately end up empty, which skips the refresh and would otherwise leave the global pointing at a stale, already-destroyed `HMENU` from a previous right-click. Fixed by resetting it to `nullptr` right before rebuilding the context menu each time.

**Warning:** The `src/Settings.h` file here results from several iterations of AI and manual editing, and the line wrapping doesn't match what a proper generation with `bun cmd/gen-settings.ts` would produce. But I don't want to bloat my computer again by installing Visual Studio just for this.