### PR TITLE
feat: remove print action from main toolbar

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,26 @@
+# SumatraPDF Enhanced
+
+SumatraPDF Enhanced is a personal open-source project based on
+[SumatraPDF](https://github.com/sumatrapdfreader/sumatrapdf).
+
+The goal is to explore how a lightweight PDF reader can be improved
+with modern user-interface design, reading features, productivity
+tools, and selected PDF editing capabilities while preserving the
+performance and lightweight nature of the original project.
+
+## Project Goals
+
+- Preserve fast startup and low resource usage
+- Improve the reading experience
+- Modernize selected parts of the user interface
+- Add practical productivity features
+- Improve PDF annotation and document workflows
+- Maintain a clean and maintainable codebase
+
+## Development Philosophy
+
+Features should provide meaningful value without unnecessarily
+increasing application complexity, startup time, or resource usage.
+
+This project is developed as a learning and portfolio project while
+respecting the original project's license and attribution requirements.

--- a/src/Toolbar.cpp
+++ b/src/Toolbar.cpp
@@ -62,7 +62,6 @@ struct ToolbarButtonInfo {
 
 static ToolbarButtonInfo gToolbarButtons[] = {
     {gIconFileOpen, CmdOpenFile, _TRN("Open")},
-    {gIconPrint, CmdPrint, _TRN("Print")},
     {nullptr, 0, nullptr},          // separator
     {nullptr, PageInfoId, nullptr}, // text box for page number + show current page / no of pages
     {gIconPagePrev, CmdGoToPrevPage, _TRN("Previous Page")},


### PR DESCRIPTION
## Summary

- Remove the Print button from the main toolbar.
- Keep the underlying Print command and keyboard shortcut unchanged.
- Preserve the existing toolbar layout and functionality.

## Testing

- Built successfully with Visual Studio 2022.
- Launched the modified application successfully.
- Verified that the Print button is no longer displayed in the main toolbar.
- Verified that the Print functionality remains available.

## Scope

This is a UI-only change. The underlying Print command has not been removed.