### PR TITLE
security(workflows): pin Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: windows-2025-vs2026
     steps:
       - name: Check out source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           # needed to calc build number via git log --oneline
           fetch-depth: 0
 
       - name: Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Build
         env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,13 +40,13 @@ jobs:
             build-mode: manual
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -55,14 +55,14 @@ jobs:
         run: bun .\cmd\build.ts -codeql
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
         with:
           category: "/language:${{matrix.language}}"
           output: sarif-results
           upload: failure-only
 
       - name: filter-sarif
-        uses: advanced-security/filter-sarif@v1
+        uses: advanced-security/filter-sarif@f3b8118a9349d88f7b1c0c488476411145b6270d # v1
         with:
           patterns: |
             -**/*
@@ -71,12 +71,12 @@ jobs:
           output: sarif-results/cpp.sarif
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
         with:
           sarif_file: sarif-results/cpp.sarif
 
       - name: Upload loc as a Build Artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: sarif-results
           path: sarif-results

--- a/.github/workflows/windows-daily.yml
+++ b/.github/workflows/windows-daily.yml
@@ -22,13 +22,13 @@ jobs:
     runs-on: windows-2025-vs2026
     steps:
       - name: Check out source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           # needed to calc build number via git log --oneline
           fetch-depth: 0
 
       - name: Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       # cmd/build.ts -daily only builds master of this repo; on a fork or a
       # branch it exits early
@@ -47,10 +47,10 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Check out source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       # ASan so the run catches memory errors the tests walk into, not just
       # wrong behavior. Produces out/dbg64_asan/SumatraPDF-static.exe plus the
@@ -68,7 +68,7 @@ jobs:
       # what the failing tests left behind: screenshots, logs, generated files
       - name: Upload test output
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: test-output
           path: |


### PR DESCRIPTION
## Summary
- Pin every third-party `uses:` reference in `.github/workflows/*.yml` to its current tag's full commit SHA, keeping the tag as a trailing comment for readability.
- Covers `actions/checkout@v6`, `oven-sh/setup-bun@v2`, `github/codeql-action/{init,analyze,upload-sarif}@v4`, `advanced-security/filter-sarif@v1`, and `actions/upload-artifact@v6`.
- Tags are mutable — a compromised maintainer account on any of those action repos (or a supply-chain attack on the action itself, as happened to `tj-actions/changed-files` in 2025) can retarget a tag a workflow already trusts, silently changing what code runs with whatever that job's token/secrets can reach. SHAs can't be moved.

## Test plan
- [x] All 3 modified workflow files parse as valid YAML.
- [x] Diffed to confirm only the `uses:` lines changed, nothing else touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)