### PR TITLE
security(workflows): set persist-credentials: false on checkout steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           # needed to calc build number via git log --oneline
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Install bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2

--- a/.github/workflows/windows-daily.yml
+++ b/.github/workflows/windows-daily.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           # needed to calc build number via git log --oneline
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -50,6 +51,8 @@ jobs:
     steps:
       - name: Check out source code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Install bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2


### PR DESCRIPTION
## Summary
- Add `persist-credentials: false` to all four `actions/checkout` steps across `build.yml`, `codeql.yml`, and `windows-daily.yml`.
- `actions/checkout` persists the job's `GITHUB_TOKEN` in `.git/config` by default for the rest of the job. None of these workflows push or commit with that ambient credential — I checked `cmd/build.ts` and everything it calls under `cmd/helper/` for `git push`/`git commit` and found none, only reads (`git log`, `rev-parse`, and a single-file `git checkout` to revert a generated header in `ci-build.ts`).
- Turning it off shrinks what any code running later in these jobs — third-party actions, the bun build scripts themselves, or anything pulled in transitively — could do with a credential it has no reason to touch.

## Test plan
- [x] All 3 modified workflow files parse as valid YAML.
- [x] Confirmed the count of `actions/checkout` steps (4) matches the count of `persist-credentials` lines (4) after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)