### PR TITLE
security(workflows): add explicit permissions to build.yml and windows-daily.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
   repository_dispatch:
     types: [build-pre-rel]
+permissions:
+  contents: read
 jobs:
   build:
     name: Build

--- a/.github/workflows/windows-daily.yml
+++ b/.github/workflows/windows-daily.yml
@@ -13,6 +13,8 @@ on:
         description: "only these tests (comma-separated, e.g. issue-1195); empty = all"
         required: false
         default: ""
+permissions:
+  contents: read
 jobs:
   build-daily:
     name: Daily build


### PR DESCRIPTION
## Summary
- Of the three workflows in `.github/workflows`, only `codeql.yml` declared a `permissions:` block. `build.yml` and `windows-daily.yml` ran with whatever the repo/org's default `GITHUB_TOKEN` permissions happen to be — invisible from the workflow file itself, and liable to silently change if that default is ever loosened at the org level.
- Neither workflow's steps need anything beyond reading the repo (checkout) and calling `actions/upload-artifact`, which uses its own upload token rather than the job's `GITHUB_TOKEN` permissions. Added an explicit `contents: read` to both, matching the least-privilege pattern `codeql.yml` already uses.

## Test plan
- [x] Both modified files parse as valid YAML.
- [x] Confirmed no step in either workflow relies on any token scope beyond `contents: read` (no PR comments, no releases, no repo writes anywhere in the workflow YAML or the build scripts it calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)