### PR TITLE
add Windows 11 print dialog with print preview

### DIFF
--- a/premake5.files.lua
+++ b/premake5.files.lua
@@ -686,6 +686,7 @@ function sumatrapdf_files()
     "PdfTools.*",
     "PngOptimizer.*",
     "Print.*",
+    "PrintWin11.*",
     "ProgressUpdateUI.*",
     "ReadAloudHighlight.*",
     "ReadAloudPlaybackBar.*",

--- a/src/Print.cpp
+++ b/src/Print.cpp
@@ -28,6 +28,7 @@
 #include "Selection.h"
 #include "SumatraDialogs.h"
 #include "Translations.h"
+#include "PrintWin11.h"
 #include "Print.h"
 
 class AbortCookieManager {
@@ -611,6 +612,93 @@ static float SanitizePrintZoom(float zoom, float fallback, Str why, Size paperSi
     return 1.f;
 }
 
+bool CalculatePrintPageLayout(EngineBase& engine, int pageNo, const Print_Advanced_Data& advanced, Size paperSize,
+                              Rect printable, float dpiX, float dpiY, bool printPortrait, Str printerName,
+                              PrintPageLayout& layout) {
+    float fileDPI = engine.GetFileDPI();
+    if (!(fileDPI > 0) || !isfinite(fileDPI)) {
+        fileDPI = 96.f;
+    }
+    float dpiFactor = std::min(SafePrintDiv(dpiX, fileDPI), SafePrintDiv(dpiY, fileDPI));
+    if (!IsValidPrintZoom(dpiFactor)) {
+        dpiFactor = 1.f;
+    }
+
+    SizeF pageSize = engine.PageMediabox(pageNo).Size();
+    int rotation = 0;
+    if (advanced.autoRotate && pageSize.dx > pageSize.dy) {
+        rotation += 90;
+        std::swap(pageSize.dx, pageSize.dy);
+    }
+    rotation = (rotation % 180) == 0 ? 0 : 270;
+    if (!printPortrait) {
+        rotation = (rotation + 90) % 360;
+        std::swap(pageSize.dx, pageSize.dy);
+    }
+    if (advanced.extraRotation != 0) {
+        rotation = (rotation + advanced.extraRotation) % 360;
+        if (advanced.extraRotation == 90 || advanced.extraRotation == 270) {
+            std::swap(pageSize.dx, pageSize.dy);
+        }
+    }
+
+    float zoom = dpiFactor;
+    Point offset(-printable.x, -printable.y);
+    float pageDx = pageSize.dx > 0 ? pageSize.dx : 1.f;
+    float pageDy = pageSize.dy > 0 ? pageSize.dy : 1.f;
+    Rect stretch;
+    bool isStretch = advanced.scale == PrintScaleAdv::Stretch;
+
+    if (isStretch) {
+        zoom = std::max(SafePrintDiv((float)printable.dx, pageDx), SafePrintDiv((float)printable.dy, pageDy));
+        offset = Point(0, 0);
+        stretch = Rect(0, 0, printable.dx, printable.dy);
+    } else if (advanced.scale != PrintScaleAdv::None) {
+        RectF rect = engine.PageContentBox(pageNo, RenderTarget::Print);
+        if (rect.IsEmpty() || rect.dx <= 0 || rect.dy <= 0) {
+            rect = engine.PageMediabox(pageNo);
+        }
+        RectF contentBox = engine.Transform(rect, pageNo, 1.0, rotation);
+        float contentDx = contentBox.dx > 0 ? contentBox.dx : pageDx;
+        float contentDy = contentBox.dy > 0 ? contentBox.dy : pageDy;
+        zoom = std::min(
+            SafePrintDiv((float)printable.dx, contentDx),
+            std::min(SafePrintDiv((float)printable.dy, contentDy),
+                     std::min(SafePrintDiv((float)paperSize.dx, pageDx), SafePrintDiv((float)paperSize.dy, pageDy))));
+        if (advanced.scale == PrintScaleAdv::Shrink && dpiFactor < zoom) {
+            zoom = dpiFactor;
+        }
+        offset.x += (int)((float)paperSize.dx - (pageSize.dx * zoom)) / 2;
+        offset.y += (int)((float)paperSize.dy - (pageSize.dy * zoom)) / 2;
+        RectF onPaper((float)printable.x + (float)offset.x + (contentBox.x * zoom),
+                      (float)printable.y + (float)offset.y + (contentBox.y * zoom), contentBox.dx * zoom,
+                      contentBox.dy * zoom);
+        if (onPaper.x < (float)printable.x) {
+            offset.x += (int)((float)printable.x - onPaper.x);
+        } else if (onPaper.BR().x > (float)printable.BR().x) {
+            offset.x -= (int)(onPaper.BR().x - (float)printable.BR().x);
+        }
+        if (onPaper.y < (float)printable.y) {
+            offset.y += (int)((float)printable.y - onPaper.y);
+        } else if (onPaper.BR().y > (float)printable.BR().y) {
+            offset.y -= (int)(onPaper.BR().y - (float)printable.BR().y);
+        }
+    }
+
+    zoom = SanitizePrintZoom(zoom, dpiFactor, StrL("page"), paperSize, printable, dpiX, dpiY, fileDPI, dpiFactor,
+                             printerName);
+    if (advanced.centerHorizontally && advanced.scale == PrintScaleAdv::None) {
+        offset.x += (int)((float)paperSize.dx - (pageSize.dx * zoom)) / 2;
+    }
+
+    layout.zoom = zoom;
+    layout.rotation = rotation;
+    layout.offset = offset;
+    layout.stretch = stretch;
+    layout.isStretch = isStretch;
+    return true;
+}
+
 // Rasterize a page (or, for selections, a page-space sub-rectangle of it) onto
 // the printer HDC in horizontal device-pixel bands. Banding bounds peak memory
 // regardless of page size / printer DPI, replacing the old "shrink to half
@@ -952,112 +1040,16 @@ static bool PrintToDevice(const PrintData& pd) {
                 continue;
             }
 
-            SizeF pSize = engine.PageMediabox((int)pageNo).Size();
-            int rotation = 0;
-            // Turn the document by 90 deg if it isn't in portrait mode & if autoRotation is not disabled
-            if (pd.advData.autoRotate && pSize.dx > pSize.dy) {
-                rotation += 90;
-                std::swap(pSize.dx, pSize.dy);
-            }
-            // make sure not to print upside-down
-            rotation = (rotation % 180) == 0 ? 0 : 270;
-            // finally turn the page by (another) 90 deg in landscape mode
-            if (!bPrintPortrait) {
-                rotation = (rotation + 90) % 360;
-                std::swap(pSize.dx, pSize.dy);
-            }
-            // apply the user-requested extra rotation on top, to fix wrong
-            // orientation (e.g. upside-down output on virtual printers) (#1246)
-            if (pd.advData.extraRotation != 0) {
-                rotation = (rotation + pd.advData.extraRotation) % 360;
-                if (pd.advData.extraRotation == 90 || pd.advData.extraRotation == 270) {
-                    std::swap(pSize.dx, pSize.dy);
-                }
-            }
-
-            // dpiFactor means no physical zoom
-            float zoom = dpiFactor;
-            // offset of the top-left corner of the page from the printable area
-            // (negative values move the page into the left/top margins, etc.);
-            // offset adjustments are needed because the GDI coordinate system
-            // starts at the corner of the printable area and we rather want to
-            // center the page on the physical paper (except for PrintScaleNone
-            // where the page starts at the very top left of the physical paper so
-            // that printing forms/labels of varying size remains reliably possible)
-            Point offset(-printable.x, -printable.y);
-
-            float pdx = pSize.dx > 0 ? pSize.dx : 1.f;
-            float pdy = pSize.dy > 0 ? pSize.dy : 1.f;
-
-            if (PrintScaleAdv::Stretch == pd.advData.scale) {
-                // stretch the page to fill the whole printable area in both
-                // dimensions, ignoring the aspect ratio (issue #2220). Render at
-                // a zoom large enough that the bitmap is at least as big as the
-                // printable area in both dimensions (so we only ever downscale
-                // one of them); the StretchBlt in the blit loop below then resizes
-                // it to exactly fill the printable area.
-                zoom = std::max(SafePrintDiv((float)printable.dx, pdx), SafePrintDiv((float)printable.dy, pdy));
-                offset = Point(0, 0);
-            } else if (pd.advData.scale != PrintScaleAdv::None) {
-                // make sure to fit all content into the printable area when scaling
-                // and the whole document page on the physical paper
-                RectF rect = engine.PageContentBox((int)pageNo, RenderTarget::Print);
-                // empty content box (e.g. failed image crop) → use full mediabox
-                if (rect.IsEmpty() || rect.dx <= 0 || rect.dy <= 0) {
-                    rect = engine.PageMediabox((int)pageNo);
-                }
-                RectF cbox = engine.Transform(rect, (int)pageNo, 1.0, rotation);
-                float cdx = cbox.dx > 0 ? cbox.dx : pdx;
-                float cdy = cbox.dy > 0 ? cbox.dy : pdy;
-                zoom = std::min(
-                    SafePrintDiv((float)printable.dx, cdx),
-                    std::min(SafePrintDiv((float)printable.dy, cdy),
-                             std::min(SafePrintDiv((float)paperSize.dx, pdx), SafePrintDiv((float)paperSize.dy, pdy))));
-                // use the correct zoom values, if the page fits otherwise
-                // and the user didn't ask for anything else (default setting)
-                if (PrintScaleAdv::Shrink == pd.advData.scale && dpiFactor < zoom) {
-                    zoom = dpiFactor;
-                }
-                // center the page on the physical paper
-                offset.x += (int)((float)paperSize.dx - (pSize.dx * zoom)) / 2;
-                offset.y += (int)((float)paperSize.dy - (pSize.dy * zoom)) / 2;
-                // make sure that no content lies in the non-printable paper margins
-                RectF onPaper((float)printable.x + (float)offset.x + (cbox.x * zoom),
-                              (float)printable.y + (float)offset.y + (cbox.y * zoom), cbox.dx * zoom, cbox.dy * zoom);
-                if (onPaper.x < (float)printable.x) {
-                    offset.x += (int)((float)printable.x - onPaper.x);
-                } else if (onPaper.BR().x > (float)printable.BR().x) {
-                    offset.x -= (int)(onPaper.BR().x - (float)printable.BR().x);
-                }
-                if (onPaper.y < (float)printable.y) {
-                    offset.y += (int)((float)printable.y - onPaper.y);
-                } else if (onPaper.BR().y > (float)printable.BR().y) {
-                    offset.y -= (int)(onPaper.BR().y - (float)printable.BR().y);
-                }
-            }
-
-            zoom = SanitizePrintZoom(zoom, dpiFactor, StrL("page"), paperSize, printable, logPixelsX, logPixelsY,
-                                     fileDPI, dpiFactor, pd.printer->name);
-
-            // optionally center the page horizontally on the physical paper
-            // (issue #348). The scaling modes already center the page and Stretch
-            // fills the paper, so this only affects placement for PrintScaleNone,
-            // where the page is otherwise aligned to the top-left corner. Useful
-            // for printing a page smaller than the paper (e.g. envelopes or A5
-            // stock fed through a tray that centers the paper).
-            if (pd.advData.centerHorizontally && PrintScaleAdv::None == pd.advData.scale) {
-                offset.x += (int)((float)paperSize.dx - (pSize.dx * zoom)) / 2;
-            }
-
+            PrintPageLayout layout;
+            CalculatePrintPageLayout(engine, (int)pageNo, pd.advData, paperSize, printable, logPixelsX, logPixelsY,
+                                     bPrintPortrait, pd.printer->name, layout);
             RectF mediabox = engine.PageMediabox((int)pageNo);
-            if (PrintScaleAdv::Stretch == pd.advData.scale) {
-                // resize the rendered page to exactly fill the printable area
-                Rect stretchRc(0, 0, printable.dx, printable.dy);
-                PrintPageInBands(engine, hdc, (int)pageNo, zoom, rotation, mediabox, Point(0, 0), &stretchRc,
-                                 RenderTarget::Print, abortCookie, progressCb);
+            if (layout.isStretch) {
+                PrintPageInBands(engine, hdc, (int)pageNo, layout.zoom, layout.rotation, mediabox, Point(0, 0),
+                                 &layout.stretch, RenderTarget::Print, abortCookie, progressCb);
             } else {
-                PrintPageInBands(engine, hdc, (int)pageNo, zoom, rotation, mediabox, offset, nullptr,
-                                 RenderTarget::Print, abortCookie, progressCb);
+                PrintPageInBands(engine, hdc, (int)pageNo, layout.zoom, layout.rotation, mediabox, layout.offset,
+                                 nullptr, RenderTarget::Print, abortCookie, progressCb);
             }
 
             res = EndPage(hdc);
@@ -1368,6 +1360,10 @@ void PrintCurrentFile(MainWindow* win, bool waitForCompletion) {
         return;
     }
 #endif
+
+    if (!waitForCompletion && TryPrintCurrentFileWin11(win, defaultScaleAdv)) {
+        return;
+    }
 
     if (win->printThread) {
         uint type = MB_ICONEXCLAMATION | MB_YESNO | MbRtlReadingMaybe();

--- a/src/Print.cpp
+++ b/src/Print.cpp
@@ -1308,23 +1308,6 @@ static void SetDevModeCopies(HGLOBAL hDevMode, short copies) {
     }
 }
 
-/* Show Print Dialog box to allow user to select the printer
-and the pages to print.
-
-For reference: In order to print with Adobe Reader instead: ViewWithAcrobat(win, L"/P");
-
-Note: The following only applies for printing as image
-
-Creates a new dummy page for each page with a large zoom factor,
-and then uses StretchDIBits to copy this to the printer's dc.
-
-So far have tested printing from XP to
- - Acrobat Professional 6 (note that acrobat is usually set to
-   downgrade the resolution of its bitmaps to 150dpi)
- - HP Laserjet 2300d
- - HP Deskjet D4160
- - Lexmark Z515 inkjet, which should cover most bases.
-*/
 enum {
     MAXPAGERANGES = 10
 };

--- a/src/Print.h
+++ b/src/Print.h
@@ -49,6 +49,19 @@ void GetPrintersInfo(str::Builder& out);
 
 class EngineBase;
 struct MainWindow;
+struct Print_Advanced_Data;
+
+struct PrintPageLayout {
+    float zoom = 1.f;
+    int rotation = 0;
+    Point offset;
+    Rect stretch;
+    bool isStretch = false;
+};
+
+bool CalculatePrintPageLayout(EngineBase& engine, int pageNo, const Print_Advanced_Data& advanced, Size paperSize,
+                              Rect printable, float dpiX, float dpiY, bool printPortrait, Str printerName,
+                              PrintPageLayout& layout);
 
 // result of command-line printing; the numeric values double as the process
 // exit code so an automated caller can tell why printing failed (issue #3478)

--- a/src/PrintWin11.cpp
+++ b/src/PrintWin11.cpp
@@ -1,0 +1,743 @@
+/* Copyright 2026 the SumatraPDF project authors (see AUTHORS file).
+   License: GPLv3 */
+
+#include "base/Base.h"
+#include "base/File.h"
+#include "base/GuessFileType.h"
+#include "base/Pixmap.h"
+#include "base/ScopedWin.h"
+#include "gui/UIModels.h"
+
+#include "Settings.h"
+#include "DocController.h"
+#include "EngineBase.h"
+#include "EngineAll.h"
+#include "AppSettings.h"
+#include "DisplayModel.h"
+#include "MainWindow.h"
+#include "WindowTab.h"
+#include "SumatraDialogs.h"
+#include "Print.h"
+
+#if defined(_MSC_VER) && __has_include(<PrintManagerInterop.h>) && __has_include(<DocumentSource.h>)
+
+#pragma push_macro("NTDDI_VERSION")
+#undef NTDDI_VERSION
+#define NTDDI_VERSION NTDDI_WIN8
+#include <d2d1_1.h>
+#include <d3d11_1.h>
+#include <dxgi1_2.h>
+#include <roapi.h>
+#include <wincodec.h>
+#include <windows.foundation.h>
+#include <windows.graphics.printing.h>
+#include <DocumentSource.h>
+#include <DocumentTarget.h>
+#include <PrintManagerInterop.h>
+#include <PrintPreview.h>
+#include <wrl.h>
+#include <wrl/event.h>
+#pragma pop_macro("NTDDI_VERSION")
+
+#include "PrintWin11.h"
+
+using Microsoft::WRL::Callback;
+using Microsoft::WRL::ComPtr;
+using Microsoft::WRL::MakeAndInitialize;
+using Microsoft::WRL::RuntimeClass;
+using Microsoft::WRL::RuntimeClassFlags;
+using Microsoft::WRL::WinRtClassicComMix;
+
+namespace Printing = ABI::Windows::Graphics::Printing;
+namespace Foundation = ABI::Windows::Foundation;
+
+using PrintRequestedHandler =
+    Foundation::ITypedEventHandler<Printing::PrintManager*, Printing::PrintTaskRequestedEventArgs*>;
+
+static decltype(&WindowsCreateString) gWindowsCreateString;
+
+struct WinRtApi {
+    decltype(&RoInitialize) roInitialize = nullptr;
+    decltype(&RoUninitialize) roUninitialize = nullptr;
+    decltype(&RoGetActivationFactory) roGetActivationFactory = nullptr;
+    decltype(&WindowsCreateString) windowsCreateString = nullptr;
+    decltype(&WindowsDeleteString) windowsDeleteString = nullptr;
+
+    bool Load() {
+        HMODULE combase = LoadLibraryW(L"combase.dll");
+        if (!combase) {
+            return false;
+        }
+        roInitialize = (decltype(roInitialize))GetProcAddress(combase, "RoInitialize");
+        roUninitialize = (decltype(roUninitialize))GetProcAddress(combase, "RoUninitialize");
+        roGetActivationFactory = (decltype(roGetActivationFactory))GetProcAddress(combase, "RoGetActivationFactory");
+        windowsCreateString = (decltype(windowsCreateString))GetProcAddress(combase, "WindowsCreateString");
+        windowsDeleteString = (decltype(windowsDeleteString))GetProcAddress(combase, "WindowsDeleteString");
+        gWindowsCreateString = windowsCreateString;
+        return roInitialize && roUninitialize && roGetActivationFactory && windowsCreateString && windowsDeleteString;
+    }
+};
+
+class D2DFactoryLock {
+    ID2D1Multithread* multithread = nullptr;
+
+  public:
+    explicit D2DFactoryLock(ID2D1Multithread* multithread) : multithread(multithread) {
+        if (multithread) {
+            multithread->Enter();
+        }
+    }
+
+    ~D2DFactoryLock() {
+        if (multithread) {
+            multithread->Leave();
+        }
+    }
+};
+
+class PrintGraphics {
+    ComPtr<ID2D1Factory1> d2dFactory;
+    ComPtr<ID2D1Multithread> d2dMultithread;
+    ComPtr<ID3D11Device> d3dDevice;
+    ComPtr<ID2D1Device> d2dDevice;
+    ComPtr<IWICImagingFactory> wicFactory;
+
+  public:
+    HRESULT Initialize() {
+        if (d2dDevice) {
+            return S_OK;
+        }
+
+        HMODULE d2dModule = LoadLibraryW(L"d2d1.dll");
+        HMODULE d3dModule = LoadLibraryW(L"d3d11.dll");
+        if (!d2dModule || !d3dModule) {
+            return HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND);
+        }
+        using D2D1CreateFactoryFn = HRESULT(WINAPI*)(D2D1_FACTORY_TYPE, REFIID, const D2D1_FACTORY_OPTIONS*, void**);
+        auto d2dCreateFactory = (D2D1CreateFactoryFn)GetProcAddress(d2dModule, "D2D1CreateFactory");
+        auto d3dCreateDevice = (decltype(&D3D11CreateDevice))GetProcAddress(d3dModule, "D3D11CreateDevice");
+        if (!d2dCreateFactory || !d3dCreateDevice) {
+            return HRESULT_FROM_WIN32(ERROR_PROC_NOT_FOUND);
+        }
+
+        D2D1_FACTORY_OPTIONS factoryOptions{};
+        HRESULT hr = d2dCreateFactory(D2D1_FACTORY_TYPE_MULTI_THREADED, __uuidof(ID2D1Factory1), &factoryOptions,
+                                      (void**)d2dFactory.GetAddressOf());
+        if (FAILED(hr)) {
+            return hr;
+        }
+        hr = d2dFactory.As(&d2dMultithread);
+        if (FAILED(hr)) {
+            return hr;
+        }
+
+        UINT flags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
+        hr = d3dCreateDevice(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, flags, nullptr, 0, D3D11_SDK_VERSION,
+                             &d3dDevice, nullptr, nullptr);
+        if (FAILED(hr)) {
+            hr = d3dCreateDevice(nullptr, D3D_DRIVER_TYPE_WARP, nullptr, flags, nullptr, 0, D3D11_SDK_VERSION,
+                                 &d3dDevice, nullptr, nullptr);
+        }
+        if (FAILED(hr)) {
+            return hr;
+        }
+
+        ComPtr<IDXGIDevice> dxgiDevice;
+        hr = d3dDevice.As(&dxgiDevice);
+        if (SUCCEEDED(hr)) {
+            hr = d2dFactory->CreateDevice(dxgiDevice.Get(), &d2dDevice);
+        }
+        if (SUCCEEDED(hr)) {
+            hr = CoCreateInstance(CLSID_WICImagingFactory, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&wicFactory));
+        }
+        return hr;
+    }
+
+    HRESULT CreatePreviewSurface(float width, float height, float dpi, ID3D11Texture2D** texture,
+                                 IDXGISurface** surface, ID2D1DeviceContext** context) {
+        if (!texture || !surface || !context || width <= 0 || height <= 0) {
+            return E_INVALIDARG;
+        }
+        *texture = nullptr;
+        *surface = nullptr;
+        *context = nullptr;
+
+        HRESULT hr = Initialize();
+        if (FAILED(hr)) {
+            return hr;
+        }
+
+        D2DFactoryLock factoryLock(d2dMultithread.Get());
+        D3D11_TEXTURE2D_DESC textureDesc{};
+        textureDesc.Width = (UINT)ceilf(width * dpi / 96.f);
+        textureDesc.Height = (UINT)ceilf(height * dpi / 96.f);
+        textureDesc.MipLevels = 1;
+        textureDesc.ArraySize = 1;
+        textureDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+        textureDesc.SampleDesc.Count = 1;
+        textureDesc.Usage = D3D11_USAGE_DEFAULT;
+        textureDesc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+
+        ComPtr<ID3D11Texture2D> localTexture;
+        hr = d3dDevice->CreateTexture2D(&textureDesc, nullptr, &localTexture);
+        ComPtr<IDXGISurface> localSurface;
+        if (SUCCEEDED(hr)) {
+            hr = localTexture.As(&localSurface);
+        }
+        ComPtr<ID2D1DeviceContext> localContext;
+        if (SUCCEEDED(hr)) {
+            hr = d2dDevice->CreateDeviceContext(D2D1_DEVICE_CONTEXT_OPTIONS_NONE, &localContext);
+        }
+
+        D2D1_BITMAP_PROPERTIES1 bitmapProperties{};
+        bitmapProperties.pixelFormat = D2D1::PixelFormat(DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_IGNORE);
+        bitmapProperties.dpiX = dpi;
+        bitmapProperties.dpiY = dpi;
+        bitmapProperties.bitmapOptions = D2D1_BITMAP_OPTIONS_TARGET | D2D1_BITMAP_OPTIONS_CANNOT_DRAW;
+        ComPtr<ID2D1Bitmap1> targetBitmap;
+        if (SUCCEEDED(hr)) {
+            hr = localContext->CreateBitmapFromDxgiSurface(localSurface.Get(), &bitmapProperties, &targetBitmap);
+        }
+        if (SUCCEEDED(hr)) {
+            localContext->SetTarget(targetBitmap.Get());
+            localContext->SetDpi(dpi, dpi);
+            *texture = localTexture.Detach();
+            *surface = localSurface.Detach();
+            *context = localContext.Detach();
+        }
+        return hr;
+    }
+
+    HRESULT CreatePrintControl(IPrintDocumentPackageTarget* packageTarget, float rasterDpi,
+                               ID2D1PrintControl** printControl) {
+        if (!packageTarget || !printControl) {
+            return E_INVALIDARG;
+        }
+        *printControl = nullptr;
+        HRESULT hr = Initialize();
+        if (FAILED(hr)) {
+            return hr;
+        }
+        D2D1_PRINT_CONTROL_PROPERTIES properties{};
+        properties.rasterDPI = rasterDpi;
+        properties.colorSpace = D2D1_COLOR_SPACE_SRGB;
+        properties.fontSubset = D2D1_PRINT_FONT_SUBSET_MODE_DEFAULT;
+        return d2dDevice->CreatePrintControl(wicFactory.Get(), packageTarget, &properties, printControl);
+    }
+
+    HRESULT CreateDeviceContext(ID2D1DeviceContext** context) {
+        if (!context) {
+            return E_INVALIDARG;
+        }
+        *context = nullptr;
+        HRESULT hr = Initialize();
+        if (FAILED(hr)) {
+            return hr;
+        }
+        return d2dDevice->CreateDeviceContext(D2D1_DEVICE_CONTEXT_OPTIONS_NONE, context);
+    }
+};
+
+static Pixmap* ConvertToBgra(Pixmap* source) {
+    if (!source) {
+        return nullptr;
+    }
+    if (source->format == PixmapFormat::BGRA8 && source->data) {
+        return source;
+    }
+    if (source->hbmp) {
+        Pixmap* converted = PixmapCopyAs32bppDIB(source);
+        FreePixmap(source);
+        return converted;
+    }
+    if (!source->data) {
+        FreePixmap(source);
+        return nullptr;
+    }
+
+    Pixmap* converted = AllocPixmap(source->width, source->height, PixmapFormat::BGRA8);
+    if (!converted) {
+        FreePixmap(source);
+        return nullptr;
+    }
+    for (int y = 0; y < source->height; y++) {
+        const u8* src = source->data + (size_t)y * source->stride;
+        u8* dst = converted->data + (size_t)y * converted->stride;
+        for (int x = 0; x < source->width; x++) {
+            if (source->format == PixmapFormat::BGR8) {
+                dst[0] = src[0];
+                dst[1] = src[1];
+                dst[2] = src[2];
+                dst[3] = 255;
+                src += 3;
+            } else {
+                dst[0] = src[2];
+                dst[1] = src[1];
+                dst[2] = src[0];
+                dst[3] = src[3];
+                src += 4;
+            }
+            dst += 4;
+        }
+    }
+    FreePixmap(source);
+    return converted;
+}
+
+class PrintDocumentSource final
+    : public RuntimeClass<RuntimeClassFlags<WinRtClassicComMix>, Printing::IPrintDocumentSource,
+                          IPrintDocumentPageSource, IPrintPreviewPageCollection> {
+  public:
+    HRESULT STDMETHODCALLTYPE GetRuntimeClassName(HSTRING* runtimeName) override {
+        if (!runtimeName) {
+            return E_POINTER;
+        }
+        *runtimeName = nullptr;
+        if (!gWindowsCreateString) {
+            return E_NOTIMPL;
+        }
+        const WCHAR* name = L"Windows.Graphics.Printing.IPrintDocumentSource";
+        return gWindowsCreateString(name, (UINT32)wcslen(name), runtimeName);
+    }
+
+    HRESULT STDMETHODCALLTYPE GetTrustLevel(TrustLevel* trustLevel) override {
+        if (!trustLevel) {
+            return E_POINTER;
+        }
+        *trustLevel = BaseTrust;
+        return S_OK;
+    }
+
+  private:
+    EngineBase* engine = nullptr;
+    int currentPage = 1;
+    Print_Advanced_Data advanced;
+    float previewDpi = 96.f;
+    Mutex mutex;
+    Vec<int> pages;
+    ComPtr<Printing::IPrintTaskOptionsCore> previewOptions;
+    ComPtr<IPrintPreviewDxgiPackageTarget> previewTarget;
+    PrintGraphics graphics;
+
+    int DocumentPage(UINT32 jobPage) const {
+        if (jobPage < 1 || jobPage > (UINT32)len(pages)) {
+            return 0;
+        }
+        return pages[(int)jobPage - 1];
+    }
+
+    void UseAllPages() {
+        pages.Reset();
+        for (int pageNo = 1; pageNo <= engine->PageCount(); pageNo++) {
+            pages.Append(pageNo);
+        }
+    }
+
+    void ReadPageRanges(IInspectable* options) {
+        pages.Reset();
+        ComPtr<Printing::IPrintTaskOptions2> options2;
+        HRESULT hr = options->QueryInterface(IID_PPV_ARGS(&options2));
+        ComPtr<__FIVector_1_Windows__CGraphics__CPrinting__CPrintPageRange> ranges;
+        if (SUCCEEDED(hr)) {
+            hr = options2->get_CustomPageRanges(&ranges);
+        }
+        UINT32 count = 0;
+        if (SUCCEEDED(hr)) {
+            hr = ranges->get_Size(&count);
+        }
+        if (FAILED(hr) || count == 0) {
+            UseAllPages();
+            return;
+        }
+        for (UINT32 i = 0; i < count; i++) {
+            ComPtr<Printing::IPrintPageRange> range;
+            if (FAILED(ranges->GetAt(i, range.GetAddressOf()))) {
+                continue;
+            }
+            INT32 first = 0;
+            INT32 last = 0;
+            if (FAILED(range->get_FirstPageNumber(&first)) || FAILED(range->get_LastPageNumber(&last))) {
+                continue;
+            }
+            first = std::max(1, first);
+            last = std::min(engine->PageCount(), last);
+            for (int pageNo = first; pageNo <= last; pageNo++) {
+                pages.Append(pageNo);
+            }
+        }
+        if (len(pages) == 0) {
+            UseAllPages();
+        }
+    }
+
+    HRESULT DrawPage(ID2D1DeviceContext* context, int pageNo, const Printing::PrintPageDescription& description,
+                     float renderDpi) {
+        float unitsPerDip = renderDpi / 96.f;
+        Size paperSize((int)ceilf(description.PageSize.Width * unitsPerDip),
+                       (int)ceilf(description.PageSize.Height * unitsPerDip));
+        Rect printable((int)lroundf(description.ImageableRect.X * unitsPerDip),
+                       (int)lroundf(description.ImageableRect.Y * unitsPerDip),
+                       (int)lroundf(description.ImageableRect.Width * unitsPerDip),
+                       (int)lroundf(description.ImageableRect.Height * unitsPerDip));
+        PrintPageLayout layout;
+        CalculatePrintPageLayout(*engine, pageNo, advanced, paperSize, printable, renderDpi, renderDpi,
+                                 paperSize.dx < paperSize.dy, StrL("Windows print dialog"), layout);
+
+        RenderPageArgs args(pageNo, layout.zoom, layout.rotation, nullptr, RenderTarget::Print);
+        Pixmap* pixmap = ConvertToBgra(engine->RenderPage(args));
+        if (!pixmap || !pixmap->data) {
+            FreePixmap(pixmap);
+            return E_FAIL;
+        }
+
+        D2D1_BITMAP_PROPERTIES1 bitmapProperties{};
+        bitmapProperties.pixelFormat = D2D1::PixelFormat(DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_IGNORE);
+        bitmapProperties.dpiX = renderDpi;
+        bitmapProperties.dpiY = renderDpi;
+        ComPtr<ID2D1Bitmap1> bitmap;
+        HRESULT hr = context->CreateBitmap(D2D1::SizeU((UINT32)pixmap->width, (UINT32)pixmap->height), pixmap->data,
+                                           (UINT32)pixmap->stride, &bitmapProperties, &bitmap);
+        if (SUCCEEDED(hr)) {
+            Rect target;
+            if (layout.isStretch) {
+                target = Rect(printable.x, printable.y, printable.dx, printable.dy);
+            } else {
+                target =
+                    Rect(printable.x + layout.offset.x, printable.y + layout.offset.y, pixmap->width, pixmap->height);
+            }
+            D2D1_RECT_F destination = D2D1::RectF(target.x / unitsPerDip, target.y / unitsPerDip,
+                                                  target.BR().x / unitsPerDip, target.BR().y / unitsPerDip);
+            context->DrawBitmap(bitmap.Get(), destination, 1.f, D2D1_INTERPOLATION_MODE_HIGH_QUALITY_CUBIC, nullptr,
+                                nullptr);
+        }
+        FreePixmap(pixmap);
+        return hr;
+    }
+
+  public:
+    HRESULT RuntimeClassInitialize(EngineBase* sourceEngine, int currentPage, PrintScaleAdv scale, float previewDpi) {
+        if (!sourceEngine) {
+            return E_INVALIDARG;
+        }
+        engine = sourceEngine;
+        engine->AddRef();
+        this->currentPage = currentPage;
+        advanced = Print_Advanced_Data(PrintRangeAdv::All, scale);
+        this->previewDpi = previewDpi;
+        UseAllPages();
+        return S_OK;
+    }
+
+    ~PrintDocumentSource() override { SafeEngineRelease(&engine); }
+
+    HRESULT STDMETHODCALLTYPE GetPreviewPageCollection(IPrintDocumentPackageTarget* packageTarget,
+                                                       IPrintPreviewPageCollection** collection) override {
+        if (!packageTarget || !collection) {
+            return E_INVALIDARG;
+        }
+        *collection = nullptr;
+        HRESULT hr = packageTarget->GetPackageTarget(ID_PREVIEWPACKAGETARGET_DXGI, IID_PPV_ARGS(&previewTarget));
+        if (SUCCEEDED(hr)) {
+            hr = QueryInterface(IID_PPV_ARGS(collection));
+        }
+        return hr;
+    }
+
+    HRESULT STDMETHODCALLTYPE Paginate(UINT32, IInspectable* options) override {
+        if (!options || !previewTarget) {
+            return E_INVALIDARG;
+        }
+        ScopedMutex lock(&mutex);
+        ReadPageRanges(options);
+        HRESULT hr = options->QueryInterface(IID_PPV_ARGS(&previewOptions));
+        if (SUCCEEDED(hr)) {
+            hr = previewTarget->InvalidatePreview();
+        }
+        if (SUCCEEDED(hr)) {
+            hr = previewTarget->SetJobPageCount(PageCountType::FinalPageCount, (UINT32)len(pages));
+        }
+        return hr;
+    }
+
+    HRESULT STDMETHODCALLTYPE MakePage(UINT32 desiredJobPage, float width, float height) override {
+        if (!previewTarget || width <= 0 || height <= 0) {
+            return E_INVALIDARG;
+        }
+        ScopedMutex lock(&mutex);
+        UINT32 jobPage = desiredJobPage == JOB_PAGE_APPLICATION_DEFINED ? 1 : desiredJobPage;
+        int pageNo = DocumentPage(jobPage);
+        if (!pageNo || !previewOptions) {
+            return E_INVALIDARG;
+        }
+
+        Printing::PrintPageDescription description{};
+        HRESULT hr = previewOptions->GetPageDescription(jobPage, &description);
+        if (FAILED(hr)) {
+            return hr;
+        }
+        float scale = std::min(width / description.PageSize.Width, height / description.PageSize.Height);
+        float renderDpi = std::max(24.f, previewDpi * scale);
+
+        ComPtr<ID3D11Texture2D> texture;
+        ComPtr<IDXGISurface> surface;
+        ComPtr<ID2D1DeviceContext> context;
+        hr = graphics.CreatePreviewSurface(width, height, previewDpi, &texture, &surface, &context);
+        if (FAILED(hr)) {
+            return hr;
+        }
+        context->BeginDraw();
+        context->Clear(D2D1::ColorF(D2D1::ColorF::White));
+        context->SetTransform(D2D1::Matrix3x2F::Scale(scale, scale));
+        hr = DrawPage(context.Get(), pageNo, description, renderDpi);
+        HRESULT drawHr = context->EndDraw();
+        if (SUCCEEDED(hr)) {
+            hr = drawHr;
+        }
+        if (SUCCEEDED(hr)) {
+            hr = previewTarget->DrawPage(jobPage, surface.Get(), previewDpi, previewDpi);
+        }
+        return hr;
+    }
+
+    HRESULT STDMETHODCALLTYPE MakeDocument(IInspectable* options, IPrintDocumentPackageTarget* packageTarget) override {
+        if (!options || !packageTarget) {
+            return E_INVALIDARG;
+        }
+        ScopedMutex lock(&mutex);
+        ReadPageRanges(options);
+        ComPtr<Printing::IPrintTaskOptionsCore> optionCore;
+        HRESULT hr = options->QueryInterface(IID_PPV_ARGS(&optionCore));
+        if (FAILED(hr)) {
+            return hr;
+        }
+
+        Printing::PrintPageDescription firstDescription{};
+        hr = optionCore->GetPageDescription(1, &firstDescription);
+        float rasterDpi = (float)std::min(firstDescription.DpiX, firstDescription.DpiY);
+        rasterDpi = std::max(96.f, std::min(300.f, rasterDpi));
+        ComPtr<ID2D1PrintControl> printControl;
+        if (SUCCEEDED(hr)) {
+            hr = graphics.CreatePrintControl(packageTarget, rasterDpi, &printControl);
+        }
+
+        for (UINT32 jobPage = 1; SUCCEEDED(hr) && jobPage <= (UINT32)len(pages); jobPage++) {
+            Printing::PrintPageDescription description{};
+            hr = optionCore->GetPageDescription(jobPage, &description);
+            ComPtr<ID2D1DeviceContext> context;
+            if (SUCCEEDED(hr)) {
+                hr = graphics.CreateDeviceContext(&context);
+            }
+            ComPtr<ID2D1CommandList> commands;
+            if (SUCCEEDED(hr)) {
+                hr = context->CreateCommandList(&commands);
+            }
+            if (SUCCEEDED(hr)) {
+                context->SetTarget(commands.Get());
+                context->BeginDraw();
+                context->Clear(D2D1::ColorF(D2D1::ColorF::White));
+                hr = DrawPage(context.Get(), DocumentPage(jobPage), description, rasterDpi);
+                HRESULT drawHr = context->EndDraw();
+                if (SUCCEEDED(hr)) {
+                    hr = drawHr;
+                }
+            }
+            if (SUCCEEDED(hr)) {
+                hr = commands->Close();
+            }
+            if (SUCCEEDED(hr)) {
+                D2D1_SIZE_F pageSize = D2D1::SizeF(description.PageSize.Width, description.PageSize.Height);
+                hr = printControl->AddPage(commands.Get(), pageSize, nullptr);
+            }
+        }
+        if (printControl) {
+            HRESULT closeHr = printControl->Close();
+            if (SUCCEEDED(hr)) {
+                hr = closeHr;
+            }
+        }
+        return hr;
+    }
+};
+
+class Win11PrintSession {
+    WinRtApi api;
+    bool roInitialized = false;
+    HWND hwnd = nullptr;
+    EventRegistrationToken token{};
+    ComPtr<IPrintManagerInterop> interop;
+    ComPtr<Printing::IPrintManager> manager;
+    ComPtr<PrintRequestedHandler> requestedHandler;
+    ComPtr<PrintDocumentSource> source;
+    WStr jobTitle;
+
+    HRESULT OnPrintRequested(Printing::IPrintTaskRequestedEventArgs* args) {
+        ComPtr<Printing::IPrintTaskRequest> request;
+        HRESULT hr = args->get_Request(&request);
+        ComPtr<Printing::IPrintTaskSourceRequestedHandler> sourceHandler;
+        if (SUCCEEDED(hr)) {
+            ComPtr<PrintDocumentSource> retainedSource = source;
+            sourceHandler = Callback<Printing::IPrintTaskSourceRequestedHandler>(
+                [retainedSource](Printing::IPrintTaskSourceRequestedArgs* sourceArgs) -> HRESULT {
+                    ComPtr<Printing::IPrintDocumentSource> documentSource;
+                    HRESULT sourceHr = retainedSource.As(&documentSource);
+                    if (SUCCEEDED(sourceHr)) {
+                        sourceHr = sourceArgs->SetSource(documentSource.Get());
+                    }
+                    return sourceHr;
+                });
+            if (!sourceHandler) {
+                hr = E_OUTOFMEMORY;
+            }
+        }
+
+        HSTRING title = nullptr;
+        if (SUCCEEDED(hr)) {
+            hr = api.windowsCreateString(jobTitle.s, (UINT32)len(jobTitle), &title);
+        }
+        ComPtr<Printing::IPrintTask> task;
+        if (SUCCEEDED(hr)) {
+            hr = request->CreatePrintTask(title, sourceHandler.Get(), &task);
+        }
+        if (title) {
+            api.windowsDeleteString(title);
+        }
+
+        ComPtr<Printing::IPrintTaskOptionsCore> options;
+        if (SUCCEEDED(hr)) {
+            hr = task->get_Options(&options);
+        }
+        ComPtr<Printing::IPrintTaskOptions2> options2;
+        if (SUCCEEDED(hr) && SUCCEEDED(options.As(&options2))) {
+            ComPtr<Printing::IPrintPageRangeOptions> rangeOptions;
+            if (SUCCEEDED(options2->get_PageRangeOptions(&rangeOptions))) {
+                rangeOptions->put_AllowAllPages(true);
+                rangeOptions->put_AllowCurrentPage(true);
+                rangeOptions->put_AllowCustomSetOfPages(true);
+            }
+        }
+        ComPtr<Printing::IPrintTask2> task2;
+        if (SUCCEEDED(hr) && SUCCEEDED(task.As(&task2))) {
+            task2->put_IsPreviewEnabled(true);
+        }
+        return hr;
+    }
+
+  public:
+    ~Win11PrintSession() {
+        if (manager && token.value) {
+            manager->remove_PrintTaskRequested(token);
+        }
+        wstr::Free(jobTitle);
+        if (roInitialized) {
+            api.roUninitialize();
+        }
+    }
+
+    HRESULT Initialize(HWND hwnd, EngineBase* engine, int currentPage, PrintScaleAdv scale, float previewDpi) {
+        if (!api.Load()) {
+            return HRESULT_FROM_WIN32(ERROR_PROC_NOT_FOUND);
+        }
+        HRESULT hr = api.roInitialize(RO_INIT_SINGLETHREADED);
+        if (SUCCEEDED(hr)) {
+            roInitialized = true;
+        } else if (hr != RPC_E_CHANGED_MODE) {
+            return hr;
+        }
+
+        EngineBase* printEngine = engine->Clone();
+        if (!printEngine && engine->FilePath()) {
+            printEngine = CreateEngineFromFile(engine->FilePath(), nullptr, false);
+        }
+        if (!printEngine) {
+            printEngine = engine;
+            printEngine->AddRef();
+        }
+        hr = MakeAndInitialize<PrintDocumentSource>(&source, printEngine, currentPage, scale, previewDpi);
+        printEngine->Release();
+        if (FAILED(hr)) {
+            return hr;
+        }
+
+        this->hwnd = hwnd;
+        TempStr baseName = path::GetBaseNameTemp(engine->FilePath());
+        jobTitle = wstr::Dup(ToWStrTemp(baseName ? baseName : StrL("SumatraPDF document")));
+
+        HSTRING className = nullptr;
+        const WCHAR* runtimeClass = RuntimeClass_Windows_Graphics_Printing_PrintManager;
+        hr = api.windowsCreateString(runtimeClass, (UINT32)wcslen(runtimeClass), &className);
+        if (SUCCEEDED(hr)) {
+            hr = api.roGetActivationFactory(className, IID_PPV_ARGS(&interop));
+        }
+        if (className) {
+            api.windowsDeleteString(className);
+        }
+        if (SUCCEEDED(hr)) {
+            hr = interop->GetForWindow(hwnd, IID_PPV_ARGS(&manager));
+        }
+        if (SUCCEEDED(hr)) {
+            requestedHandler = Callback<PrintRequestedHandler>(
+                [this](Printing::IPrintManager*, Printing::IPrintTaskRequestedEventArgs* args) -> HRESULT {
+                    return OnPrintRequested(args);
+                });
+            if (!requestedHandler) {
+                hr = E_OUTOFMEMORY;
+            }
+        }
+        if (SUCCEEDED(hr)) {
+            hr = manager->add_PrintTaskRequested(requestedHandler.Get(), &token);
+        }
+        return hr;
+    }
+
+    HRESULT Show() {
+        ComPtr<__FIAsyncOperation_1_boolean> operation;
+        return interop->ShowPrintUIForWindowAsync(hwnd, IID_PPV_ARGS(&operation));
+    }
+};
+
+static Win11PrintSession* gPrintSession = nullptr;
+
+bool TryPrintCurrentFileWin11(MainWindow* win, PrintScaleAdv defaultScale) {
+    if (!win || !win->hwndFrame || !win->AsFixed()) {
+        return false;
+    }
+    if (win->CurrentTab()->selectionOnPage) {
+        return false;
+    }
+    EngineBase* engine = win->AsFixed()->GetEngine();
+    if (!engine) {
+        return false;
+    }
+
+    HDC hdc = GetDC(win->hwndFrame);
+    float previewDpi = hdc ? (float)GetDeviceCaps(hdc, LOGPIXELSX) : 96.f;
+    if (hdc) {
+        ReleaseDC(win->hwndFrame, hdc);
+    }
+    previewDpi = std::max(96.f, std::min(240.f, previewDpi));
+
+    delete gPrintSession;
+    gPrintSession = new Win11PrintSession();
+    HRESULT hr =
+        gPrintSession->Initialize(win->hwndFrame, engine, win->AsFixed()->CurrentPageNo(), defaultScale, previewDpi);
+    if (SUCCEEDED(hr)) {
+        hr = gPrintSession->Show();
+    }
+    if (FAILED(hr)) {
+        logf("Windows print dialog unavailable: 0x%08x\n", (uint)hr);
+        delete gPrintSession;
+        gPrintSession = nullptr;
+        return false;
+    }
+    return true;
+}
+
+#else
+
+#include "PrintWin11.h"
+
+bool TryPrintCurrentFileWin11(MainWindow*, PrintScaleAdv) {
+    return false;
+}
+
+#endif

--- a/src/PrintWin11.h
+++ b/src/PrintWin11.h
@@ -1,0 +1,7 @@
+/* Copyright 2026 the SumatraPDF project authors (see AUTHORS file).
+   License: GPLv3 */
+
+struct MainWindow;
+enum class PrintScaleAdv;
+
+bool TryPrintCurrentFileWin11(MainWindow* win, PrintScaleAdv defaultScale);

--- a/vs2022/SumatraPDF-static.vcxproj
+++ b/vs2022/SumatraPDF-static.vcxproj
@@ -1227,6 +1227,7 @@
     <ClInclude Include="..\src\PdfTools.h" />
     <ClInclude Include="..\src\PngOptimizer.h" />
     <ClInclude Include="..\src\Print.h" />
+    <ClInclude Include="..\src\PrintWin11.h" />
     <ClInclude Include="..\src\ProgressUpdateUI.h" />
     <ClInclude Include="..\src\ReadAloudHighlight.h" />
     <ClInclude Include="..\src\ReadAloudPlaybackBar.h" />
@@ -1465,6 +1466,7 @@
     <ClCompile Include="..\src\PdfTools.cpp" />
     <ClCompile Include="..\src\PngOptimizer.cpp" />
     <ClCompile Include="..\src\Print.cpp" />
+    <ClCompile Include="..\src\PrintWin11.cpp" />
     <ClCompile Include="..\src\ReadAloudHighlight.cpp" />
     <ClCompile Include="..\src\ReadAloudPlaybackBar.cpp" />
     <ClCompile Include="..\src\ReaderModel.cpp" />

--- a/vs2022/SumatraPDF-static.vcxproj.filters
+++ b/vs2022/SumatraPDF-static.vcxproj.filters
@@ -333,6 +333,9 @@
     <ClInclude Include="..\src\Print.h">
       <Filter>src</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\PrintWin11.h">
+      <Filter>src</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\ProgressUpdateUI.h">
       <Filter>src</Filter>
     </ClInclude>
@@ -936,6 +939,9 @@
       <Filter>src</Filter>
     </ClCompile>
     <ClCompile Include="..\src\Print.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\PrintWin11.cpp">
       <Filter>src</Filter>
     </ClCompile>
     <ClCompile Include="..\src\ReadAloudHighlight.cpp">

--- a/vs2022/SumatraPDF.vcxproj
+++ b/vs2022/SumatraPDF.vcxproj
@@ -1255,6 +1255,7 @@ cd ../out/rel64_prefast_asan &amp; if not exist InstallerData.dat ..\..\bin\Make
     <ClInclude Include="..\src\PdfTools.h" />
     <ClInclude Include="..\src\PngOptimizer.h" />
     <ClInclude Include="..\src\Print.h" />
+    <ClInclude Include="..\src\PrintWin11.h" />
     <ClInclude Include="..\src\ProgressUpdateUI.h" />
     <ClInclude Include="..\src\ReadAloudHighlight.h" />
     <ClInclude Include="..\src\ReadAloudPlaybackBar.h" />
@@ -1494,6 +1495,7 @@ cd ../out/rel64_prefast_asan &amp; if not exist InstallerData.dat ..\..\bin\Make
     <ClCompile Include="..\src\PdfTools.cpp" />
     <ClCompile Include="..\src\PngOptimizer.cpp" />
     <ClCompile Include="..\src\Print.cpp" />
+    <ClCompile Include="..\src\PrintWin11.cpp" />
     <ClCompile Include="..\src\ReadAloudHighlight.cpp" />
     <ClCompile Include="..\src\ReadAloudPlaybackBar.cpp" />
     <ClCompile Include="..\src\ReaderModel.cpp" />

--- a/vs2022/SumatraPDF.vcxproj.filters
+++ b/vs2022/SumatraPDF.vcxproj.filters
@@ -333,6 +333,9 @@
     <ClInclude Include="..\src\Print.h">
       <Filter>src</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\PrintWin11.h">
+      <Filter>src</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\ProgressUpdateUI.h">
       <Filter>src</Filter>
     </ClInclude>
@@ -939,6 +942,9 @@
       <Filter>src</Filter>
     </ClCompile>
     <ClCompile Include="..\src\Print.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\PrintWin11.cpp">
       <Filter>src</Filter>
     </ClCompile>
     <ClCompile Include="..\src\ReadAloudHighlight.cpp">


### PR DESCRIPTION
Reuses SumatraPDF's own rendering to drive the native Windows 11 print dialog (WinRT `PrintManager`) with live page previews.

## What's included
- New `src/PrintWin11.{cpp,h}` implementing the WinRT print pipeline: `IPrintDocumentSource` + `IPrintPreviewPageCollection` + `IPrintDocumentPageSource`, rendering pages through D2D/D3D.
- The page-layout math (zoom/rotation/offset/stretch) is shared between the GDI and WinRT print paths via `CalculatePrintPageLayout()`, so both dialogs place content identically.
- `PrintCurrentFile()` falls back to the classic `PrintDlgEx` path when Win11 printing is unavailable (older Windows, selection printing, command-line printing).

## Notes
- Windows-only; requires the Windows 10/11 SDK print headers (`PrintManagerInterop.h`, `DocumentSource.h`). The Win11 path is compiled out gracefully where those aren't available.
- Builds clean on both `SumatraPDF.vcxproj` and `SumatraPDF-static.vcxproj` (Debug/x64, `/W4 /WX`).