### PR TITLE
Add fast path to CharLowerW()

### DIFF
--- a/src/TextSearch.cpp
+++ b/src/TextSearch.cpp
@@ -297,6 +297,20 @@ static int FoldCaseWCharPortable(int c) {
 }
 #endif
 
+#if OS_WIN
+// CharLowerW() wrapper with a fast path for ASCII.
+// In testing, this improved overall search performance by ~3x.
+static int FastCharLowerW(int c) {
+    if (c < 0x80) {
+        if (c >= 'A' && c <= 'Z') {
+            return c + ('a' - 'A');
+        }
+        return c;
+    }
+    return (WCHAR)(uintptr_t)CharLowerW((LPWSTR)(uintptr_t)c);
+}
+#endif
+
 // Locale-independent Unicode case folding for search. CharLowerW folds accented
 // letters (e.g. É->é, Ş->ş) regardless of the CRT locale, unlike towlower() or
 // the ASCII-only fast paths we used before.
@@ -311,7 +325,7 @@ static int FoldCaseForSearch(int c) {
     }
     if (c > 0 && c <= 0xffff) {
 #if OS_WIN
-        return (WCHAR)(uintptr_t)CharLowerW((LPWSTR)(uintptr_t)c);
+        return FastCharLowerW(c);
 #else
         return FoldCaseWCharPortable(c);
 #endif


### PR DESCRIPTION
At work I open large PDFs quite frequently. The ARM CPU Manual is a good example (~17,000 pages), and it's what I used in my testing. (You can get a copy here: https://documentation-service.arm.com/static/6a43ea3a072af726f8ef38c0?token=)

Searching through PDFs of this size can be somewhat slow. On my machine (Snapdragon X2 Elite) searching through the entire PDF can take ~1,600ms. The is in the "hot" case, where we assume that MuPDF has already extracted the text from all of the pages. That process takes about 20 seconds, and is a different beast entirely.

Having taken ETL traces, the performance bottleneck seems to be calling CharLowerW() many many times while performing "case folding" on the search string and the document text.

In my testing, this change drops the time for a full document search from 1,600ms, to about 500ms.

Here are some before and after graphs from WPA to illustrate the difference:

<img width="3223" height="1523" alt="image" src="https://github.com/user-attachments/assets/2f3fcc2c-5948-49b6-978c-9cef77a30015" />

These traces were captured by running a script that searched for 4 different "nonsense" phrases that do not appear in the document, spaced 1 second apart. Note the overall CPU time for the process drops from ~6,600ms to ~2,100ms.