### PR TITLE
Build certain translation units on hot paths with /O2

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -201,6 +201,18 @@ function favor_speed()
   filter {}
 end
 
+-- /O2 for individual translation units that on the hot path.
+-- This is more targeted than favor_speed() which can increase 
+-- binary size more than desired.
+function favor_speed_files(files)
+  for _, f in ipairs(files) do
+    filter { "files:" .. f, "configurations:Release", "platforms:not x64_asan" }
+    optimize "Speed"
+    enablepch "Off"
+  end
+  filter {}
+end
+
 -- per-workspace setting that differ in clang-cl.exe vs cl.exe builds
 function clang_conf()
   filter "options:with-clang"
@@ -935,6 +947,14 @@ workspace "SumatraPDF"
     kind "StaticLib"
     language "C"
     mixed_dbg_rel_conf()
+    favor_speed_files {
+      "ext/mupdf/source/pdf/pdf-cmap.c", "ext/mupdf/source/pdf/pdf-lex.c",
+      "ext/mupdf/source/fitz/document.c", "ext/mupdf/source/pdf/pdf-object.c",
+      "ext/mupdf/source/fitz/stext-device.c", "ext/mupdf/source/fitz/geometry.c",
+      "ext/mupdf/source/pdf/pdf-unicode.c", "ext/mupdf/source/pdf/pdf-op-run.c",
+      "ext/mupdf/source/pdf/pdf-interpret.c", "ext/mupdf/source/pdf/pdf-metrics.c",
+      "ext/mupdf/source/fitz/strtof.c", "ext/mupdf/source/fitz/memory.c",
+    }
     -- for openjpeg, OPJ_STATIC is alrady defined in load-jpx.c
     -- so we can't double-define it
     defines { "USE_JPIP", "OPJ_EXPORTS", "HAVE_LCMS2MT=1", "HAVE_WEBP=1" }
@@ -1344,6 +1364,7 @@ workspace "SumatraPDF"
     gui_files()
     uia_files()
     engines_files()
+    favor_speed_files { "src/TextSearch.cpp", "src/EngineMupdf.cpp" }
     sumatrapdf_files()
 
     setup_base_pch()
@@ -1443,6 +1464,7 @@ workspace "SumatraPDF"
     gui_files()
     uia_files()
     engines_files()
+    favor_speed_files { "src/TextSearch.cpp", "src/EngineMupdf.cpp" }
     sumatrapdf_files()
     filter "configurations:Debug or DebugFull"
       files { "src/AppUnitTests.cpp" }

--- a/vs2022/SumatraPDF-static.vcxproj
+++ b/vs2022/SumatraPDF-static.vcxproj
@@ -1403,7 +1403,14 @@
     <ClCompile Include="..\src\EngineDump.cpp" />
     <ClCompile Include="..\src\EngineEbook.cpp" />
     <ClCompile Include="..\src\EngineImages.cpp" />
-    <ClCompile Include="..\src\EngineMupdf.cpp" />
+    <ClCompile Include="..\src\EngineMupdf.cpp">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">MaxSpeed</Optimization>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\src\EnginePs.cpp" />
     <ClCompile Include="..\src\EutlTrust.cpp" />
     <ClCompile Include="..\src\ExifDump.cpp" />
@@ -1545,7 +1552,14 @@
     </ClCompile>
     <ClCompile Include="..\src\Tester.cpp" />
     <ClCompile Include="..\src\Tests.cpp" />
-    <ClCompile Include="..\src\TextSearch.cpp" />
+    <ClCompile Include="..\src\TextSearch.cpp">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">MaxSpeed</Optimization>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\src\TextSelection.cpp" />
     <ClCompile Include="..\src\TextToSpeech.cpp" />
     <ClCompile Include="..\src\TextViewWnd.cpp" />

--- a/vs2022/SumatraPDF.vcxproj
+++ b/vs2022/SumatraPDF.vcxproj
@@ -1431,7 +1431,14 @@ cd ../out/rel64_prefast_asan &amp; if not exist InstallerData.dat ..\..\bin\Make
     <ClCompile Include="..\src\EngineDump.cpp" />
     <ClCompile Include="..\src\EngineEbook.cpp" />
     <ClCompile Include="..\src\EngineImages.cpp" />
-    <ClCompile Include="..\src\EngineMupdf.cpp" />
+    <ClCompile Include="..\src\EngineMupdf.cpp">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">MaxSpeed</Optimization>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\src\EnginePs.cpp" />
     <ClCompile Include="..\src\EutlTrust.cpp" />
     <ClCompile Include="..\src\ExifDump.cpp" />
@@ -1574,7 +1581,14 @@ cd ../out/rel64_prefast_asan &amp; if not exist InstallerData.dat ..\..\bin\Make
     </ClCompile>
     <ClCompile Include="..\src\Tester.cpp" />
     <ClCompile Include="..\src\Tests.cpp" />
-    <ClCompile Include="..\src\TextSearch.cpp" />
+    <ClCompile Include="..\src\TextSearch.cpp">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">MaxSpeed</Optimization>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\src\TextSelection.cpp" />
     <ClCompile Include="..\src\TextToSpeech.cpp" />
     <ClCompile Include="..\src\TextViewWnd.cpp" />

--- a/vs2022/mupdf.vcxproj
+++ b/vs2022/mupdf.vcxproj
@@ -1005,7 +1005,14 @@
     <ClCompile Include="..\ext\mupdf\source\fitz\device.c" />
     <ClCompile Include="..\ext\mupdf\source\fitz\directory.c" />
     <ClCompile Include="..\ext\mupdf\source\fitz\document-all.c" />
-    <ClCompile Include="..\ext\mupdf\source\fitz\document.c" />
+    <ClCompile Include="..\ext\mupdf\source\fitz\document.c">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">MaxSpeed</Optimization>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\ext\mupdf\source\fitz\draw-affine.c" />
     <ClCompile Include="..\ext\mupdf\source\fitz\draw-blend.c" />
     <ClCompile Include="..\ext\mupdf\source\fitz\draw-device.c" />
@@ -1036,7 +1043,14 @@
     <ClCompile Include="..\ext\mupdf\source\fitz\filter-thunder.c" />
     <ClCompile Include="..\ext\mupdf\source\fitz\font.c" />
     <ClCompile Include="..\ext\mupdf\source\fitz\ftoa.c" />
-    <ClCompile Include="..\ext\mupdf\source\fitz\geometry.c" />
+    <ClCompile Include="..\ext\mupdf\source\fitz\geometry.c">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">MaxSpeed</Optimization>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\ext\mupdf\source\fitz\getopt.c" />
     <ClCompile Include="..\ext\mupdf\source\fitz\glyph.c" />
     <ClCompile Include="..\ext\mupdf\source\fitz\glyphbox.c" />
@@ -1064,7 +1078,14 @@
     <ClCompile Include="..\ext\mupdf\source\fitz\load-webp.c" />
     <ClCompile Include="..\ext\mupdf\source\fitz\log.c" />
     <ClCompile Include="..\ext\mupdf\source\fitz\memento.c" />
-    <ClCompile Include="..\ext\mupdf\source\fitz\memory.c" />
+    <ClCompile Include="..\ext\mupdf\source\fitz\memory.c">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">MaxSpeed</Optimization>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\ext\mupdf\source\fitz\noto.c" />
     <ClCompile Include="..\ext\mupdf\source\fitz\ocr-device.c" />
     <ClCompile Include="..\ext\mupdf\source\fitz\options.c" />
@@ -1093,7 +1114,14 @@
     <ClCompile Include="..\ext\mupdf\source\fitz\skew.c" />
     <ClCompile Include="..\ext\mupdf\source\fitz\stext-boxer.c" />
     <ClCompile Include="..\ext\mupdf\source\fitz\stext-classify.c" />
-    <ClCompile Include="..\ext\mupdf\source\fitz\stext-device.c" />
+    <ClCompile Include="..\ext\mupdf\source\fitz\stext-device.c">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">MaxSpeed</Optimization>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\ext\mupdf\source\fitz\stext-iterator.c" />
     <ClCompile Include="..\ext\mupdf\source\fitz\stext-output.c" />
     <ClCompile Include="..\ext\mupdf\source\fitz\stext-para.c" />
@@ -1104,7 +1132,14 @@
     <ClCompile Include="..\ext\mupdf\source\fitz\stream-open.c" />
     <ClCompile Include="..\ext\mupdf\source\fitz\stream-read.c" />
     <ClCompile Include="..\ext\mupdf\source\fitz\string.c" />
-    <ClCompile Include="..\ext\mupdf\source\fitz\strtof.c" />
+    <ClCompile Include="..\ext\mupdf\source\fitz\strtof.c">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">MaxSpeed</Optimization>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\ext\mupdf\source\fitz\subset-cff.c" />
     <ClCompile Include="..\ext\mupdf\source\fitz\subset-ttf.c" />
     <ClCompile Include="..\ext\mupdf\source\fitz\svg-device.c" />
@@ -1151,7 +1186,14 @@
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-clean.c" />
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-cmap-load.c" />
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-cmap-parse.c" />
-    <ClCompile Include="..\ext\mupdf\source\pdf\pdf-cmap.c" />
+    <ClCompile Include="..\ext\mupdf\source\pdf\pdf-cmap.c">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">MaxSpeed</Optimization>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-colorspace.c" />
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-crypt.c" />
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-device.c" />
@@ -1163,20 +1205,55 @@
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-graft.c" />
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-image-rewriter.c" />
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-image.c" />
-    <ClCompile Include="..\ext\mupdf\source\pdf\pdf-interpret.c" />
+    <ClCompile Include="..\ext\mupdf\source\pdf\pdf-interpret.c">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">MaxSpeed</Optimization>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-js.c" />
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-label.c" />
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-layer.c" />
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-layout.c" />
-    <ClCompile Include="..\ext\mupdf\source\pdf\pdf-lex.c" />
+    <ClCompile Include="..\ext\mupdf\source\pdf\pdf-lex.c">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">MaxSpeed</Optimization>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-link.c" />
-    <ClCompile Include="..\ext\mupdf\source\pdf\pdf-metrics.c" />
+    <ClCompile Include="..\ext\mupdf\source\pdf\pdf-metrics.c">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">MaxSpeed</Optimization>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-nametree.c" />
-    <ClCompile Include="..\ext\mupdf\source\pdf\pdf-object.c" />
+    <ClCompile Include="..\ext\mupdf\source\pdf\pdf-object.c">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">MaxSpeed</Optimization>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-op-buffer.c" />
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-op-color.c" />
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-op-filter.c" />
-    <ClCompile Include="..\ext\mupdf\source\pdf\pdf-op-run.c" />
+    <ClCompile Include="..\ext\mupdf\source\pdf\pdf-op-run.c">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">MaxSpeed</Optimization>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-op-vectorize.c" />
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-outline.c" />
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-page.c" />
@@ -1194,7 +1271,14 @@
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-struct.c" />
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-subset.c" />
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-type3.c" />
-    <ClCompile Include="..\ext\mupdf\source\pdf\pdf-unicode.c" />
+    <ClCompile Include="..\ext\mupdf\source\pdf\pdf-unicode.c">
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MaxSpeed</Optimization>
+      <Optimization Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">MaxSpeed</Optimization>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-util.c" />
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-write.c" />
     <ClCompile Include="..\ext\mupdf\source\pdf\pdf-xobject.c" />


### PR DESCRIPTION
Similar to https://github.com/sumatrapdfreader/sumatrapdf/pull/6139, this change also targets search performance when opening large PDFs like the ARM manual. I see in the project history that you are very sensitive to binary size, so rather than building all of Sumatra and MuPDF with /O2, I instead propose selectively applying this optimization to certain TUs that are hot in traces. This improves performance by a couple percent during search, without costing much disk space.

| | Before | After | Delta |
|---|---|---|---|
| Cold first search | 19,270 ms | 18,036 ms | −1,234 ms (−6.4 %) |
| Hot search, best of 5 | 534 ms | 427 ms | −107 ms (−20 %) |
| `SumatraPDF.exe` size | 11,613,696 B | 11,704,832 B | +91,136 B (+0.8 %) |
| `libsumatrapdf.dll` size | 16,522,752 B | 16,617,472 B | +94,720 B (+0.6 %) |

As an aside: I also tried applying /O2 globally and saw that it bloated the full package size by ~2MB which I assumed you would not want.

Also here are WPA traces to show some before and after comparisons. The first screenshot here shows the "cold search" scenario
<img width="3269" height="1540" alt="image" src="https://github.com/user-attachments/assets/8ae26b80-6cac-4ef1-80f2-ce627b0da28f" />

This second screenshot shows 4 successive "hot searches"

<img width="3269" height="1540" alt="image" src="https://github.com/user-attachments/assets/24022ff9-d91f-4938-8e44-6fd244bb4ca3" />
