### PR TITLE
Proposal: lazy load the Win32 TreeView items in TOC

### DIFF
--- a/src/TableOfContents.cpp
+++ b/src/TableOfContents.cpp
@@ -702,8 +702,8 @@ void ExpandTocToCurrentPage(MainWindow* win) {
 
 static void UpdateDocTocExpansionStateRecur(TreeView* treeView, Vec<int>& tocState, TocItem* tocItem) {
     while (tocItem) {
-        // items without children cannot be toggled
-        if (tocItem->child) {
+        // items without children cannot be toggled; not yet inserted (lazy) ones are in their default state
+        if (tocItem->child && tocItem->userData) {
             // we have to query the state of the tree view item because
             // isOpenToggled is not kept in sync
             // TODO: keep toggle state on TocItem in sync
@@ -897,7 +897,7 @@ static void TocCollapseAll(TreeView* tv) {
     TocExpandToLevel(tv, 1);
     HWND hwnd = tv->hwnd;
     HTREEITEM root = TreeView_GetRoot(hwnd);
-    if (root && !TreeView_GetNextSibling(hwnd, root) && TreeView_GetChild(hwnd, root)) {
+    if (root && !TreeView_GetNextSibling(hwnd, root) && tv->treeModel->ChildCount(tv->GetTreeItemByHandle(root)) > 0) {
         TreeView_Expand(hwnd, root, TVE_EXPAND);
     }
 }
@@ -1885,6 +1885,7 @@ void CreateToc(MainWindow* win) {
     SetWindowSubclass(filterEdit->hwnd, WndProcTocFilterEdit, NextSubclassId(), (DWORD_PTR)win);
 
     auto* treeView = new TreeView();
+    treeView->lazyChildren = true;
     TreeView::CreateArgs args;
     args.parent = win->hwndTocBox;
     args.font = GetAppTreeFont();

--- a/src/gui/win/TreeView.cpp
+++ b/src/gui/win/TreeView.cpp
@@ -108,6 +108,16 @@ HWND TreeView::GetToolTipsHwnd() {
 }
 
 HTREEITEM TreeView::GetHandleByTreeItem(TreeItem item) {
+    auto h = (HTREEITEM)treeModel->GetUserData(item);
+    if (h || !lazyChildren) {
+        return h;
+    }
+    // not inserted yet: insert from the nearest inserted ancestor down
+    TreeItem parent = treeModel->Parent(item);
+    if (parent == TreeModel::kNullItem || parent == treeModel->Root()) {
+        return nullptr; // top-level items are always inserted
+    }
+    EnsureChildrenPopulated(parent, GetHandleByTreeItem(parent));
     return (HTREEITEM)treeModel->GetUserData(item);
 }
 
@@ -134,6 +144,7 @@ static TVITEMW* GetTVITEM(TreeView* tree, TreeItem ti) {
 // expand if collapse, collapse if expanded
 static void TreeViewToggle(TreeView* tree, HTREEITEM hItem, bool recursive) {
     HWND hTree = tree->hwnd;
+    tree->EnsureChildrenPopulated(tree->GetTreeItemByHandle(hItem), hItem);
     HTREEITEM child = TreeView_GetChild(hTree, hItem);
     if (!child) {
         // only applies to nodes with children
@@ -394,6 +405,11 @@ static HTREEITEM insertItemFront(TreeView* treeView, TreeItem ti, HTREEITEM pare
 
     TVITEMEXW* tvitem = &toInsert.itemex;
     FillTVITEM(tvitem, treeView->treeModel, ti);
+    if (treeView->lazyChildren && treeView->treeModel->ChildCount(ti) > 0) {
+        // show the expand button before the children are inserted
+        tvitem->mask |= TVIF_CHILDREN;
+        tvitem->cChildren = 1;
+    }
     HTREEITEM res = TreeView_InsertItem(treeView->hwnd, &toInsert);
     return res;
 }
@@ -430,9 +446,30 @@ static void PopulateTreeItem(TreeView* treeView, TreeItem item, HTREEITEM parent
         auto ti = a[i];
         HTREEITEM h = insertItemFront(treeView, ti, parent);
         tm->SetUserData(ti, (uintptr_t)h);
-        // avoid recursing if not needed because we use a lot of stack space
-        if (tm->ChildCount(ti) > 0) {
+        // avoid recursing if not needed because we use a lot of stack space.
+        // lazy: collapsed items get their children on first expand
+        if (tm->ChildCount(ti) > 0 && (!treeView->lazyChildren || tm->IsExpanded(ti))) {
             PopulateTreeItem(treeView, ti, h);
+        }
+    }
+}
+
+// lazy: insert the item's children if that hasn't happened yet
+void TreeView::EnsureChildrenPopulated(TreeItem item, HTREEITEM h) {
+    if (lazyChildren && h && !TreeView_GetChild(hwnd, h) && treeModel->ChildCount(item) > 0) {
+        PopulateTreeItem(this, item, h);
+    }
+}
+
+// GetHandleByTreeItem() trusts a handle stored in the model, so handles left
+// by an earlier population of the same model must be cleared
+static void ResetUserData(TreeModel* tm, TreeItem item) {
+    int n = tm->ChildCount(item);
+    for (int i = 0; i < n; i++) {
+        TreeItem ti = tm->ChildAt(item, i);
+        tm->SetUserData(ti, 0);
+        if (tm->ChildCount(ti) > 0) {
+            ResetUserData(tm, ti);
         }
     }
 }
@@ -454,6 +491,9 @@ void TreeView::SetTreeModel(TreeModel* tm) {
     TreeView_DeleteAllItems(hwnd);
 
     treeModel = tm;
+    if (lazyChildren) {
+        ResetUserData(tm, tm->Root());
+    }
     PopulateTree(this, tm);
     ResumeRedraw();
 
@@ -593,6 +633,14 @@ void TreeView::OnNotifyReflect(ControlBase::NotifyReflectEvent* rev) {
     }
 
     // https://docs.microsoft.com/en-us/windows/win32/controls/tvn-selchanged
+    if (code == TVN_ITEMEXPANDING && lazyChildren) {
+        NMTREEVIEWW* nmExp = (NMTREEVIEWW*)lp;
+        if (nmExp->action == TVE_EXPAND) {
+            EnsureChildrenPopulated((TreeItem)nmExp->itemNew.lParam, nmExp->itemNew.hItem);
+        }
+        return;
+    }
+
     if (code == TVN_SELCHANGED) {
         // log(StrL("tv: TVN_SELCHANGED\n"));
         // only needed when a handler paints beyond the label; without one the

--- a/src/gui/win/WinGui.h
+++ b/src/gui/win/WinGui.h
@@ -1051,6 +1051,7 @@ struct TreeView : ControlBase {
     void Clear();
 
     HTREEITEM GetHandleByTreeItem(TreeItem item);
+    void EnsureChildrenPopulated(TreeItem item, HTREEITEM h);
     TempStr GetDefaultTooltipTemp(TreeItem ti);
     TreeItem GetItemAt(int x, int y);
     TreeItem GetTreeItemByHandle(HTREEITEM item);
@@ -1064,6 +1065,9 @@ struct TreeView : ControlBase {
     Size idealSize;
 
     TreeModel* treeModel = nullptr; // not owned by us
+    // insert children on first expand, not up front: inserting is one message
+    // (and one accessibility event) per node, ~200 ms for a 7k-node toc
+    bool lazyChildren = false;
 
     // for WM_NOTIFY with TVN_GETINFOTIP
     GetTooltipHandler onGetTooltip;

--- a/tests/issue-5918.ts
+++ b/tests/issue-5918.ts
@@ -11,10 +11,23 @@
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { cmdId, runStandalone, tmpPath } from "./util";
-import { findChildWindow, getWindowText, postMessage, sendMessage, sleep, WM_CLOSE } from "./winapi";
+import {
+  findChildWindow,
+  getWindowText,
+  postMessage,
+  sendMessage,
+  sleep,
+  treeGetNextItem,
+  TVGN_NEXT,
+  TVGN_ROOT,
+  TVM_EXPAND,
+  WM_CLOSE,
+} from "./winapi";
 import { killAndWait, launchSumatra, sendCommand, waitForExit, waitForFrame, waitForTitle } from "./win-automation";
 
 const TVM_GETCOUNT = 0x1100 + 5;
+const TVE_EXPAND = 2;
+const TVGN_CHILD = 4;
 const nFiles = 400;
 const headingsPerFile = 3;
 
@@ -38,11 +51,25 @@ function makeFolder(): string {
   return dir;
 }
 
+// The tree inserts a node's children when it is first expanded, so expand
+// everything before counting; the count is then files plus headings once the
+// background build has landed.
+function expandAll(tree: number, item: bigint): void {
+  for (let it = item; it !== 0n; it = treeGetNextItem(tree, TVGN_NEXT, it)) {
+    sendMessage(tree, TVM_EXPAND, TVE_EXPAND, it);
+    const child = treeGetNextItem(tree, TVGN_CHILD, it);
+    if (child !== 0n) {
+      expandAll(tree, child);
+    }
+  }
+}
+
 function tocItemCount(frame: number): number {
   const tree = findChildWindow(frame, "SysTreeView32");
   if (!tree) {
     return -1;
   }
+  expandAll(tree, treeGetNextItem(tree, TVGN_ROOT, 0n));
   return Number(sendMessage(tree, TVM_GETCOUNT, 0, 0));
 }
 


### PR DESCRIPTION
When switching tabs between two large PDFs (for example the ARM CPU Manual, and the Intel CPU Manual) there is a noticeable delay. Digging into this in WPA, it looks like the cost is from building and tearing down the table of contents on the left pane. Seemingly, every item in the TOC requires its own Win32k API call to instantiate. Since these PDFs contain thousands of sections, building this TreeView takes a substantial amount of time.

To fix this issue, I propose "Lazy Loading" the Win32 TreeView out of your linked datastructure internal structure. The TreeView has support for this, in that you receive a message of type TVN_ITEMEXPANDING when the user expands an item, giving us an opportunity to fill in the real children on-demand.

I will admit that this implementation was produced with Opus Fable 5.1, and I am not certain that it matches your code style. For that reason, I'm creating this PR as a "draft" assuming that you will want to reimplement something similar yourself.

Here you can see a before and after in WPA, showing the CPU time delta when running a script that switches tabs back and forth rapidly:
<img width="3269" height="2179" alt="image" src="https://github.com/user-attachments/assets/290ba687-4a21-472e-bc12-f6728c0004e8" />

And here is a video showing the before and after:
https://youtu.be/HdHr2ZNJVZo